### PR TITLE
feat: Add previous ranks hit on player chart

### DIFF
--- a/frontend/src/components/RatingChart.tsx
+++ b/frontend/src/components/RatingChart.tsx
@@ -98,18 +98,6 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
 
         if (rating_history_result !== null && char_short !== null) {
 
-            const getRankColor = (rankName: string): string => { // stole that from Distribution.tsx
-                const lowerRankName = rankName.toLowerCase();
-                if (lowerRankName.includes('iron')) return '#838fa4';
-                if (lowerRankName.includes('bronze')) return '#cc8c4e';
-                if (lowerRankName.includes('silver')) return '#b8cde6';
-                if (lowerRankName.includes('gold')) return '#f0db3b';
-                if (lowerRankName.includes('platinum')) return '#56e4bc';
-                if (lowerRankName.includes('diamond')) return '#cfbfeb';
-                if (lowerRankName.includes('vanquisher')) return '#ae71f8';
-                return 'rgba(54, 162, 235, 0.6)';
-            };
-
           rating_history_result.reverse();
 
           const lineChartData = {
@@ -128,8 +116,8 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
                     ({
                         label: rank.name,
                         data: rating_history_result.map((item: RatingsResponse) => rank.rating),
-                        borderColor: `${getRankColor(rank.name)}`,
-                        backgroundColor: `${getRankColor(rank.name)}`,
+                        borderColor: rank.color,
+                        backgroundColor: rank.color,
                         pointRadius: 0,
                         borderWidth: 1,
                     })

--- a/frontend/src/pages/Distribution.tsx
+++ b/frontend/src/pages/Distribution.tsx
@@ -39,20 +39,8 @@ const Distribution = () => {
   const [combinedMode, setCombinedMode] = React.useState(false);
   const chartRef = React.useRef<any>(null);
 
-  const getRankColor = (rankName: string): string => {
-    const lowerRankName = rankName.toLowerCase();
-    if (lowerRankName.includes('iron')) return '#838fa4';
-    if (lowerRankName.includes('bronze')) return '#cc8c4e';
-    if (lowerRankName.includes('silver')) return '#b8cde6';
-    if (lowerRankName.includes('gold')) return '#f0db3b';
-    if (lowerRankName.includes('platinum')) return '#56e4bc';
-    if (lowerRankName.includes('diamond')) return '#cfbfeb';
-    if (lowerRankName.includes('vanquisher')) return '#ae71f8';
-    return 'rgba(54, 162, 235, 0.6)';
-  };
-
   const getBorderColor = (rankName: string): string => {
-    const baseColor = getRankColor(rankName);
+    const baseColor = Utils.getRankColor(rankName);
     return baseColor;
   };
 
@@ -168,12 +156,12 @@ const Distribution = () => {
       
       chartLabels = sortedCombined.map(([name]) => name);
       chartDataValues = sortedCombined.map(([, data]) => data.count);
-      chartColors = chartLabels.map(label => getRankColor(label));
+      chartColors = chartLabels.map(label => Utils.getRankColor(label));
       chartBorderColors = chartLabels.map(label => getBorderColor(label));
     } else {
       chartLabels = distributionData.map((entry: DistributionResult) => Utils.getRankDisplayName(entry.lower_bound));
       chartDataValues = distributionData.map((entry: DistributionResult) => entry.count);
-      chartColors = chartLabels.map(label => getRankColor(label));
+      chartColors = chartLabels.map(label => Utils.getRankColor(label));
       chartBorderColors = chartLabels.map(label => getBorderColor(label));
     }
     

--- a/frontend/src/utils/Utils.jsx
+++ b/frontend/src/utils/Utils.jsx
@@ -3,26 +3,26 @@ import { StorageUtils } from "./Storage";
 import React from "react";
 
 const rankThresholds = [
-  { rating: 45000, name: 'Vanquisher', spriteX: 3, spriteY: 4 },
-  { rating: 40800, name: 'Diamond 3', spriteX: 2, spriteY: 4 },
-  { rating: 36000, name: 'Diamond 2', spriteX: 1, spriteY: 4 },
-  { rating: 32400, name: 'Diamond 1', spriteX: 0, spriteY: 4 },
-  { rating: 28400, name: 'Platinum 3', spriteX: 3, spriteY: 3 },
-  { rating: 24400, name: 'Platinum 2', spriteX: 2, spriteY: 3 },
-  { rating: 20400, name: 'Platinum 1', spriteX: 1, spriteY: 3 },
-  { rating: 18000, name: 'Gold 3', spriteX: 0, spriteY: 3 },
-  { rating: 15600, name: 'Gold 2', spriteX: 3, spriteY: 2 },
-  { rating: 13200, name: 'Gold 1', spriteX: 2, spriteY: 2 },
-  { rating: 11000, name: 'Silver 3', spriteX: 1, spriteY: 2 },
-  { rating: 8800, name: 'Silver 2', spriteX: 0, spriteY: 2 },
-  { rating: 6600, name: 'Silver 1', spriteX: 3, spriteY: 1 },
-  { rating: 5400, name: 'Bronze 3', spriteX: 2, spriteY: 1 },
-  { rating: 4200, name: 'Bronze 2', spriteX: 1, spriteY: 1 },
-  { rating: 3000, name: 'Bronze 1', spriteX: 0, spriteY: 1 },
-  { rating: 2000, name: 'Iron 3', spriteX: 3, spriteY: 0 },
-  { rating: 1000, name: 'Iron 2', spriteX: 2, spriteY: 0 },
-  { rating: 1, name: 'Iron 1', spriteX: 1, spriteY: 0 },
-  { rating: 0, name: 'Placement', spriteX: 0, spriteY: 0 }
+    { rating: 45000, name: 'Vanquisher', spriteX: 3, spriteY: 4 , color: '#ae71f8'},
+    { rating: 40800, name: 'Diamond 3', spriteX: 2, spriteY: 4, color: '#cfbfeb' },
+    { rating: 36000, name: 'Diamond 2', spriteX: 1, spriteY: 4, color: '#cfbfeb' },
+    { rating: 32400, name: 'Diamond 1', spriteX: 0, spriteY: 4, color: '#cfbfeb' },
+    { rating: 28400, name: 'Platinum 3', spriteX: 3, spriteY: 3, color: '#56e4bc' },
+    { rating: 24400, name: 'Platinum 2', spriteX: 2, spriteY: 3, color: '#56e4bc' },
+    { rating: 20400, name: 'Platinum 1', spriteX: 1, spriteY: 3, color: '#56e4bc' },
+    { rating: 18000, name: 'Gold 3', spriteX: 0, spriteY: 3, color: '#f0db3b' },
+    { rating: 15600, name: 'Gold 2', spriteX: 3, spriteY: 2, color: '#f0db3b' },
+    { rating: 13200, name: 'Gold 1', spriteX: 2, spriteY: 2, color: '#f0db3b' },
+    { rating: 11000, name: 'Silver 3', spriteX: 1, spriteY: 2, color: '#b8cde6' },
+    { rating: 8800, name: 'Silver 2', spriteX: 0, spriteY: 2, color: '#b8cde6' },
+    { rating: 6600, name: 'Silver 1', spriteX: 3, spriteY: 1, color: '#b8cde6' },
+    { rating: 5400, name: 'Bronze 3', spriteX: 2, spriteY: 1, color: '#cc8c4e' },
+    { rating: 4200, name: 'Bronze 2', spriteX: 1, spriteY: 1, color: '#cc8c4e' },
+    { rating: 3000, name: 'Bronze 1', spriteX: 0, spriteY: 1, color: '#cc8c4e' },
+    { rating: 2000, name: 'Iron 3', spriteX: 3, spriteY: 0, color: '#838fa4' },
+    { rating: 1000, name: 'Iron 2', spriteX: 2, spriteY: 0, color: '#838fa4' },
+    { rating: 1, name: 'Iron 1', spriteX: 1, spriteY: 0, color: '#838fa4' },
+    { rating: 0, name: 'Placement', spriteX: 0, spriteY: 0, color: 'rgba(54, 162, 235, 0.6)' }
 ];
 
 const Utils = {
@@ -43,6 +43,7 @@ const Utils = {
     }
     return "Placement";
   },
+  getRankColor: (name) => rankThresholds.find((r) => r.name.includes(name)).color ?? rankThresholds[rankThresholds.length - 1].color,
   displayRankIcon: (rating, size = "50px") => {
     const threshold = Utils.getRankThresholds().find(t => rating >= t.rating) || Utils.getRankThresholds()[Utils.getRankThresholds().length - 1];
     const sizeValue = parseInt(size);


### PR DESCRIPTION
As the title says, this pull request allow users to see all the previous ranks they got through in the "Rating History" chart:

<img width="1548" height="827" alt="image" src="https://github.com/user-attachments/assets/8b87b2f6-eed9-4973-a88e-c0a3f5f76617" />

The main problem from a code POV is that in order to get any rank color palette, I had to borrow the function `getRankColor`  from [`Distribution.tsx`](https://github.com/nemasu/puddle-farm/blob/master/frontend/src/pages/Distribution.tsx). Moving this function to `Utils.jsx` or (even better IMO) add it directly to [`rankThreshold`](https://github.com/nemasu/puddle-farm/blob/master/frontend/src/utils/Utils.jsx#L5) would fix that.

Let me know which option would be the best!