### PR TITLE
UI - Add player game count to user chart's duration selection

### DIFF
--- a/frontend/src/components/RatingChart.tsx
+++ b/frontend/src/components/RatingChart.tsx
@@ -32,7 +32,7 @@ import('react-chartjs-2').then(module => {
   Line = module.Line;
 });
 
-const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_ENDPOINT, latest_rating }) => {
+const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_ENDPOINT, latest_rating, total_games }) => {
 
   const [lineChartData, setLineChartData] = React.useState<LineChartData | null>(null);
   const [duration, setDuration] = React.useState<string>('100');
@@ -182,11 +182,9 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
             label="Games"
             onChange={handleDurationChange}
           >
-            <MenuItem value="100">100</MenuItem>
-            <MenuItem value="200">200</MenuItem>
-            <MenuItem value="300">300</MenuItem>
-            <MenuItem value="400">400</MenuItem>
-            <MenuItem value="500">500</MenuItem>
+            {
+              [100, 200, 300, 400, 500, total_games].sort((a, b)=> a-b).map((nbGame)=> <MenuItem value={nbGame}>{nbGame}</MenuItem>)
+            }
             <MenuItem value={customGames} onClick={handleOpenDialog}>Custom...</MenuItem>
           </Select>
         </FormControl>

--- a/frontend/src/components/RatingChart.tsx
+++ b/frontend/src/components/RatingChart.tsx
@@ -125,6 +125,11 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
                   ? { name: rawNextRank.name, color: rawNextRank.color, convertedRating: VANQUISHER_PROMOTION_RP }
                   : { name: rawNextRank.name, color: rawNextRank.color, convertedRating: Utils.convertRating(rawNextRank.rating) };
 
+          // if the user has less than 100 games, select
+          if (total_games < 100){
+            setDuration(total_games.toString());
+          }
+
           const lineChartData = {
             labels: rating_history_result.map((item: RatingsResponse) => Utils.formatUTCToLocal(item.timestamp)),
             datasets: [
@@ -183,7 +188,11 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
             onChange={handleDurationChange}
           >
             {
-              [100, 200, 300, 400, 500, total_games].sort((a, b)=> a-b).map((nbGame)=> <MenuItem value={nbGame}>{nbGame}</MenuItem>)
+              [100,  200, 300, 400, 500, total_games]
+                  .filter((value, index, self) => self.indexOf(value) === index) // remove duplicates
+                  .sort((a, b) => a - b)
+                  .filter(n => n <= total_games)
+                  .map((nbGame) => <MenuItem value={nbGame}>{nbGame}</MenuItem>)
             }
             <MenuItem value={customGames} onClick={handleOpenDialog}>Custom...</MenuItem>
           </Select>

--- a/frontend/src/components/RatingChart.tsx
+++ b/frontend/src/components/RatingChart.tsx
@@ -125,8 +125,19 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
                   ? { name: rawNextRank.name, color: rawNextRank.color, convertedRating: VANQUISHER_PROMOTION_RP }
                   : { name: rawNextRank.name, color: rawNextRank.color, convertedRating: Utils.convertRating(rawNextRank.rating) };
 
-          // if the user has less than 100 games, select
-          if (total_games < 100){
+          // if the user has less than 100 games, select his total game number
+          if (total_games < 100) {
+            setDuration(total_games.toString());
+          }
+
+          // Clamp duration to total_games if not in available options (on character change for example)
+          const items = total_games < 100
+              ? [total_games]
+              : [...Array(Math.floor(total_games / 100)).keys()]
+                  .map(i => (i + 1) * 100)
+                  .concat(total_games % 100 === 0 ? [] : [total_games]);
+          let currentDuration = parseInt(duration);
+          if (!items.includes(currentDuration) && currentDuration != parseInt(tempGames)) { // second check keep custom game count working
             setDuration(total_games.toString());
           }
 
@@ -188,11 +199,12 @@ const RatingChart: React.FC<RatingChartProps> = ({ player_id, char_short, API_EN
             onChange={handleDurationChange}
           >
             {
-              [100,  200, 300, 400, 500, total_games]
-                  .filter((value, index, self) => self.indexOf(value) === index) // remove duplicates
-                  .sort((a, b) => a - b)
-                  .filter(n => n <= total_games)
-                  .map((nbGame) => <MenuItem value={nbGame}>{nbGame}</MenuItem>)
+              (total_games < 100
+                  ? [total_games]
+                  : [...Array(Math.floor(total_games / 100)).keys()]
+                      .map(i => (i + 1) * 100)
+                      .concat(total_games % 100 === 0 ? [] : [total_games])
+              ).map((nbGame) => <MenuItem value={nbGame}>{nbGame}</MenuItem>)
             }
             <MenuItem value={customGames} onClick={handleOpenDialog}>Custom...</MenuItem>
           </Select>

--- a/frontend/src/interfaces/Player.tsx
+++ b/frontend/src/interfaces/Player.tsx
@@ -33,4 +33,5 @@ export interface RatingChartProps {
   char_short: string | undefined;
   API_ENDPOINT: string;
   latest_rating: number;
+  total_games: number;
 }

--- a/frontend/src/pages/Player.tsx
+++ b/frontend/src/pages/Player.tsx
@@ -532,7 +532,7 @@ const Player = () => {
             ) : null}
           </Box>
           {currentCharData ? (
-            <RatingChart player_id={player_id_checked} API_ENDPOINT={API_ENDPOINT} char_short={char_short} latest_rating={currentCharData.rating} />
+            <RatingChart player_id={player_id_checked} API_ENDPOINT={API_ENDPOINT} char_short={char_short} latest_rating={currentCharData.rating} total_games={currentCharData.match_count}/>
           ) : null}
           <Matchup player_id={player_id_checked} API_ENDPOINT={API_ENDPOINT} char_short={char_short} />
         </Box>


### PR DESCRIPTION
This pull request add the player game count as a possible selection for the duration of the chart.
It also filters selections higher than the player's game count, so for example if the player has 58 games it will displays `[58, Custom...]`, if he has 130 it will displays `[100, 130, Custom...]` etc (see attachment)

<img  height="300" alt="when the player has 129 games" src="https://github.com/user-attachments/assets/2ef4ecbd-1fdd-4ea5-9e93-075138bdff64" />
<img height="300" alt="when the player has 317 games" src="https://github.com/user-attachments/assets/3aff6927-7822-47d7-9331-3e0a445e6c59" />
<img  height="300" alt="when the player has less than 100 games" src="https://github.com/user-attachments/assets/3f3f771d-3e78-4c71-8814-644c949a8b09" />

