### PR TITLE
refactor(frontend): migrate data fetching from useEffect to use()+Suspense

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,118 +1,121 @@
-import { Box, Button, Typography } from "@mui/material";
-import { useEffect, useState } from "react";
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { Suspense, use, useState } from "react";
 import { Link } from "react-router-dom";
 import { Tag } from "./../components/Tag";
 import type { Supporter, TagResponse } from "../interfaces/API";
 import { JSONParse } from "../utils/JSONParse";
 
-const About = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
 
-  const [supporters, setSupporters] = useState<Supporter[]>([]);
-
-  useEffect(() => {
-    document.title = "About | Puddle Farm";
-    const fetchSupporters = async () => {
-      const supporters_response = await fetch(`${API_ENDPOINT}/supporters`);
-      const supporters_result = await supporters_response
-        .text()
-        .then((body) => {
-          const parsed = JSONParse(body);
-          return parsed;
-        });
-      setSupporters(supporters_result);
-    };
-    fetchSupporters();
-  }, []);
+const SupportersList = ({ data }: { data: Promise<Supporter[]> }) => {
+  const supporters = use(data);
 
   return (
-    <Box sx={{ m: 5 }}>
-      <Typography variant="h4" gutterBottom align="center">
-        About
-      </Typography>
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-          What is this?
+    <ul>
+      {supporters.map((supporter) => (
+        <li key={supporter.id}>
+          <Button
+            sx={{ fontSize: "16px" }}
+            component={Link}
+            to={`/player/${supporter.id}`}
+          >
+            {supporter.name}
+          </Button>
+          {supporter.tags?.map((e: TagResponse) => (
+            <Tag
+              key={e.tag}
+              style={JSON.parse(e.style)}
+              sx={{ fontSize: "0.9rem", position: "unset" }}
+            >
+              {e.tag}
+            </Tag>
+          ))}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const About = () => {
+  const [supportersPromise] = useState(() =>
+    fetch(`${API_ENDPOINT}/supporters`)
+      .then((res) => res.text())
+      .then((body) => JSONParse(body) as Supporter[])
+      .catch(() => [] as Supporter[]),
+  );
+
+  return (
+    <>
+      <title>About | Puddle Farm</title>
+      <Box sx={{ m: 5 }}>
+        <Typography variant="h4" gutterBottom align="center">
+          About
         </Typography>
-        <Typography variant="body1">
-          This website collects replay data for the game{" "}
-          <Link to="https://www.guiltygear.com/ggst/en/" target="_blank">
-            Guilty Gear Strive
-          </Link>{" "}
-          and provides statistics and rankings using the game's official rating
-          system.
-          <br />
-          It is not affiliated with Arc System Works or any other company.
-        </Typography>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+            What is this?
+          </Typography>
+          <Typography variant="body1">
+            This website collects replay data for the game{" "}
+            <Link to="https://www.guiltygear.com/ggst/en/" target="_blank">
+              Guilty Gear Strive
+            </Link>{" "}
+            and provides statistics and rankings using the game's official
+            rating system.
+            <br />
+            It is not affiliated with Arc System Works or any other company.
+          </Typography>
+        </Box>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+            What rating system is used?
+          </Typography>
+          <Typography variant="body1">
+            As of recent game updates, this site now uses the official rating
+            system provided by Guilty Gear Strive itself.
+            <br />
+          </Typography>
+        </Box>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+            Rating Sync
+          </Typography>
+          <Typography variant="body1">
+            Because we can't predict the new rating after a match result, a
+            rating sync feature was added.
+            <br />
+            Look for the refresh icon (🔄) next to your rating on your player
+            page.
+            <br />
+            It's recommended to use this feature after you're done for the day
+            to ensure your rating is up to date.
+            <br />
+            <strong>Note:</strong> Rating sync is limited to once per minute.
+          </Typography>
+        </Box>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+            I have a suggestion/question.
+          </Typography>
+          <Typography variant="body1">
+            Feel free to join Discord. The link is in the footer.
+          </Typography>
+        </Box>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+            Supporters 💜
+          </Typography>
+          <Typography variant="body1" sx={{ marginBottom: 1 }}>
+            Big thank you to the Patreon subscribers for supporting the website
+          </Typography>
+          <Typography variant="body1" component="div">
+            <Suspense fallback={<CircularProgress size={24} />}>
+              <SupportersList data={supportersPromise} />
+            </Suspense>
+          </Typography>
+        </Box>
       </Box>
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-          What rating system is used?
-        </Typography>
-        <Typography variant="body1">
-          As of recent game updates, this site now uses the official rating
-          system provided by Guilty Gear Strive itself.
-          <br />
-        </Typography>
-      </Box>
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-          Rating Sync
-        </Typography>
-        <Typography variant="body1">
-          Because we can't predict the new rating after a match result, a rating
-          sync feature was added.
-          <br />
-          Look for the refresh icon (🔄) next to your rating on your player
-          page.
-          <br />
-          It's recommended to use this feature after you're done for the day to
-          ensure your rating is up to date.
-          <br />
-          <strong>Note:</strong> Rating sync is limited to once per minute.
-        </Typography>
-      </Box>
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-          I have a suggestion/question.
-        </Typography>
-        <Typography variant="body1">
-          Feel free to join Discord. The link is in the footer.
-        </Typography>
-      </Box>
-      <Box sx={{ mb: 4 }}>
-        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-          Supporters 💜
-        </Typography>
-        <Typography variant="body1" sx={{ marginBottom: 1 }}>
-          Big thank you to the Patreon subscribers for supporting the website
-        </Typography>
-        <Typography variant="body1" component="div">
-          <ul>
-            {supporters.map((supporter) => (
-              <li key={supporter.id}>
-                <Button
-                  sx={{ fontSize: "16px" }}
-                  component={Link}
-                  to={`/player/${supporter.id}`}
-                >
-                  {supporter.name}
-                </Button>
-                {supporter.tags?.map((e: TagResponse) => (
-                  <Tag
-                    key={e.tag}
-                    style={JSON.parse(e.style)}
-                    sx={{ fontSize: "0.9rem", position: "unset" }}
-                  >
-                    {e.tag}
-                  </Tag>
-                ))}
-              </li>
-            ))}
-          </ul>
-        </Typography>
-      </Box>
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/pages/Matchup.tsx
+++ b/frontend/src/pages/Matchup.tsx
@@ -11,7 +11,7 @@ import {
   TableSortLabel,
   Typography,
 } from "@mui/material";
-import { useEffect, useState } from "react";
+import { Suspense, use, useState } from "react";
 import type {
   MatchupCharResponse,
   MatchupEntry,
@@ -19,6 +19,8 @@ import type {
 } from "../interfaces/API";
 import type { CharWinRates } from "../interfaces/Matchup";
 import { Utils } from "./../utils/Utils";
+
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
 
 const calculateAverageWinRate = (matchups: MatchupEntry[]) => {
   const totalWins = matchups.reduce((sum, m) => sum + m.wins, 0);
@@ -201,64 +203,71 @@ const MatchupTable = ({
   );
 };
 
+const MatchupContent = ({
+  data,
+}: {
+  data: Promise<MatchupResponse | undefined>;
+}) => {
+  const matchup = use(data);
+
+  return (
+    <Box sx={{ m: 2 }}>
+      <Paper elevation={2} sx={{ p: 3 }}>
+        <Typography variant="h5" gutterBottom>
+          Matchup Tables
+        </Typography>
+        <Typography variant="body1">
+          Timeframe is the past month.
+          <br />
+          Win rates are calculated by the number of wins divided by the total
+          number of games played.
+          <br />
+        </Typography>
+        {matchup?.data_all && (
+          <MatchupTable data={matchup.data_all} title="All Players" />
+        )}
+        {matchup?.data_vanq && (
+          <MatchupTable
+            data={matchup.data_vanq}
+            title="Vanquisher I Ignis and Above"
+          />
+        )}
+      </Paper>
+      <Typography sx={{ marginTop: 5 }}>
+        Statistics are updated once a day.
+      </Typography>
+      {matchup ? (
+        <Typography variant="body1">
+          Last updated: {Utils.formatUTCToLocal(matchup.last_update)}
+        </Typography>
+      ) : null}
+    </Box>
+  );
+};
+
 const Matchup = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
-
-  const [loading, setLoading] = useState(true);
-  const [matchup, setMatchup] = useState<MatchupResponse>();
-
-  useEffect(() => {
-    document.title = "Matchup | Puddle Farm";
-    fetch(`${API_ENDPOINT}/matchups`)
-      .then((response) => response.json())
-      .then((data) => {
-        setMatchup(data);
-      });
-
-    setLoading(false);
-  }, []);
+  const [matchupPromise] = useState(
+    (): Promise<MatchupResponse | undefined> =>
+      fetch(`${API_ENDPOINT}/matchups`)
+        .then((res) => res.json())
+        .catch(() => undefined),
+  );
 
   return (
     <>
-      {loading ? (
-        <CircularProgress
-          size={60}
-          variant="indeterminate"
-          disableShrink={true}
-          sx={{ position: "absolute", top: "-1px", color: "white" }}
-        />
-      ) : null}
-      <Box sx={{ m: 2 }}>
-        <Paper elevation={2} sx={{ p: 3 }}>
-          <Typography variant="h5" gutterBottom>
-            Matchup Tables
-          </Typography>
-          <Typography variant="body1">
-            Timeframe is the past month.
-            <br />
-            Win rates are calculated by the number of wins divided by the total
-            number of games played.
-            <br />
-          </Typography>
-          {matchup?.data_all && (
-            <MatchupTable data={matchup.data_all} title="All Players" />
-          )}
-          {matchup?.data_vanq && (
-            <MatchupTable
-              data={matchup.data_vanq}
-              title="Vanquisher I Ignis and Above"
-            />
-          )}
-        </Paper>
-        <Typography sx={{ marginTop: 5 }}>
-          Statistics are updated once a day.
-        </Typography>
-        {matchup ? (
-          <Typography variant="body1">
-            Last updated: {Utils.formatUTCToLocal(matchup.last_update)}
-          </Typography>
-        ) : null}
-      </Box>
+      <title>Matchup | Puddle Farm</title>
+      <Suspense
+        fallback={
+          <CircularProgress
+            size={60}
+            variant="indeterminate"
+            disableShrink={true}
+            sx={{ position: "absolute", top: "-1px", color: "white" }}
+          />
+        }
+      >
+        <MatchupContent data={matchupPromise} />
+      </Suspense>
     </>
   );
 };

--- a/frontend/src/pages/Popularity.tsx
+++ b/frontend/src/pages/Popularity.tsx
@@ -10,184 +10,184 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import { useEffect, useState } from "react";
+import { Suspense, use, useState } from "react";
 import type { PopularityResult } from "../interfaces/API";
 import { Utils } from "./../utils/Utils";
 
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+
+const PopularityContent = ({
+  data,
+}: {
+  data: Promise<PopularityResult | undefined>;
+}) => {
+  const popularity = use(data);
+
+  return (
+    <Box sx={{ m: 5 }}>
+      <Typography variant="h4" gutterBottom align="center">
+        Popularity
+      </Typography>
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+          Character Popularity Per Player (Past Month)
+        </Typography>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="body1">
+            This table shows the popularity of each character for each player in
+            the last month.
+            <br />
+            For example: If a character has a popularity of 10%, it means that
+            10% of the players have used that character.
+            <br />
+            It adds up to over 100% because players can use multiple characters.
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", flexWrap: "wrap" }}>
+          {popularity?.per_player
+            .reduce<Array<typeof popularity.per_player>>((acc, e, index) => {
+              const groupIndex = Math.floor(index / 10);
+              if (!acc[groupIndex]) {
+                acc[groupIndex] = [];
+              }
+              acc[groupIndex].push(e);
+              return acc;
+            }, [])
+            .map((group, groupIndex) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: synthetic group index, no stable id
+              <Box key={groupIndex} sx={{ width: "300px" }}>
+                <TableContainer
+                  component={Paper}
+                  sx={{ marginBottom: 4, marginRight: 2 }}
+                >
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Character</TableCell>
+                        <TableCell>Popularity</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {group.map((e) => (
+                        <TableRow key={e.name}>
+                          <TableCell>{e.name}</TableCell>
+                          <TableCell>
+                            {(
+                              (e.value / popularity.per_player_total) *
+                              100
+                            ).toFixed(2)}
+                            %
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            ))}
+        </Box>
+        <Box>
+          Total games per player:{" "}
+          {popularity && Utils.formatNumber(popularity.per_player_total)}
+        </Box>
+      </Box>
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
+          Character Popularity Per Character (Past Month)
+        </Typography>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="body1">
+            This table shows the game count per character in the last month.
+            <br />
+            For example: If a character has a popularity of 10%, it means that
+            10% of the games are with that character.
+            <br />
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", flexWrap: "wrap" }}>
+          {popularity?.per_character
+            .reduce<Array<typeof popularity.per_character>>((acc, e, index) => {
+              const groupIndex = Math.floor(index / 10);
+              if (!acc[groupIndex]) {
+                acc[groupIndex] = [];
+              }
+              acc[groupIndex].push(e);
+              return acc;
+            }, [])
+            .map((group, groupIndex) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: synthetic group index, no stable id
+              <Box key={groupIndex} sx={{ width: "300px" }}>
+                <TableContainer
+                  component={Paper}
+                  sx={{ marginBottom: 4, marginRight: 2 }}
+                >
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Character</TableCell>
+                        <TableCell>Popularity</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {group.map((e) => (
+                        <TableRow key={e.name}>
+                          <TableCell>{e.name}</TableCell>
+                          <TableCell>
+                            {(
+                              ((e.value / popularity.per_character_total) *
+                                100) /
+                              2
+                            ).toFixed(2)}
+                            %
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            ))}
+        </Box>
+        <Box>
+          Total games per character:{" "}
+          {popularity && Utils.formatNumber(popularity.per_character_total * 2)}
+        </Box>
+      </Box>
+      <Box>
+        <Typography>Statistics are updated once a day.</Typography>
+        {popularity && (
+          <Typography variant="body1">
+            Last updated: {Utils.formatUTCToLocal(popularity.last_update)}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
 const Popularity = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
-
-  const [loading, setLoading] = useState(true);
-  const [popularity, setPopularity] = useState<PopularityResult>();
-
-  useEffect(() => {
-    document.title = "Popularity | Puddle Farm";
-    fetch(`${API_ENDPOINT}/popularity`)
-      .then((response) => response.json())
-      .then((data) => {
-        setPopularity(data);
-      });
-
-    setLoading(false);
-  }, []);
+  const [popularityPromise] = useState(
+    (): Promise<PopularityResult | undefined> =>
+      fetch(`${API_ENDPOINT}/popularity`)
+        .then((res) => res.json())
+        .catch(() => undefined),
+  );
 
   return (
     <>
-      {loading ? (
-        <CircularProgress
-          size={60}
-          variant="indeterminate"
-          disableShrink={true}
-          sx={{ position: "absolute", top: "-1px", color: "white" }}
-        />
-      ) : null}
-      <Box sx={{ m: 5 }}>
-        <Typography variant="h4" gutterBottom align="center">
-          Popularity
-        </Typography>
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-            Character Popularity Per Player (Past Month)
-          </Typography>
-          <Box sx={{ mb: 4 }}>
-            <Typography variant="body1">
-              This table shows the popularity of each character for each player
-              in the last month.
-              <br />
-              For example: If a character has a popularity of 10%, it means that
-              10% of the players have used that character.
-              <br />
-              It adds up to over 100% because players can use multiple
-              characters.
-            </Typography>
-          </Box>
-          <Box sx={{ display: "flex", flexWrap: "wrap" }}>
-            {popularity?.per_player
-              .reduce<Array<typeof popularity.per_player>>((acc, e, index) => {
-                const groupIndex = Math.floor(index / 10);
-                if (!acc[groupIndex]) {
-                  acc[groupIndex] = [];
-                }
-                acc[groupIndex].push(e);
-                return acc;
-              }, [])
-              .map((group, groupIndex) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: synthetic group index, no stable id
-                <Box key={groupIndex} sx={{ width: "300px" }}>
-                  <TableContainer
-                    component={Paper}
-                    sx={{ marginBottom: 4, marginRight: 2 }}
-                  >
-                    <Table>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>Character</TableCell>
-                          <TableCell>Popularity</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {group.map((e) => (
-                          <TableRow key={e.name}>
-                            <TableCell>{e.name}</TableCell>
-                            <TableCell>
-                              {(
-                                (e.value / popularity.per_player_total) *
-                                100
-                              ).toFixed(2)}
-                              %
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </Box>
-              ))}
-          </Box>
-          <Box>
-            Total games per player:{" "}
-            {popularity?.per_player_total
-              .toString()
-              .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-          </Box>
-        </Box>
-        <Box sx={{ mb: 4 }}>
-          <Typography variant="h5" sx={{ fontWeight: "bold", marginBottom: 1 }}>
-            Character Popularity Per Character (Past Month)
-          </Typography>
-          <Box sx={{ mb: 4 }}>
-            <Typography variant="body1">
-              This table shows the game count per character in the last month.
-              <br />
-              For example: If a character has a popularity of 10%, it means that
-              10% of the games are with that character.
-              <br />
-            </Typography>
-          </Box>
-          <Box sx={{ display: "flex", flexWrap: "wrap" }}>
-            {popularity?.per_character
-              .reduce<Array<typeof popularity.per_character>>(
-                (acc, e, index) => {
-                  const groupIndex = Math.floor(index / 10);
-                  if (!acc[groupIndex]) {
-                    acc[groupIndex] = [];
-                  }
-                  acc[groupIndex].push(e);
-                  return acc;
-                },
-                [],
-              )
-              .map((group, groupIndex) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: synthetic group index, no stable id
-                <Box key={groupIndex} sx={{ width: "300px" }}>
-                  <TableContainer
-                    component={Paper}
-                    sx={{ marginBottom: 4, marginRight: 2 }}
-                  >
-                    <Table>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>Character</TableCell>
-                          <TableCell>Popularity</TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {group.map((e) => (
-                          <TableRow key={e.name}>
-                            <TableCell>{e.name}</TableCell>
-                            <TableCell>
-                              {(
-                                ((e.value / popularity.per_character_total) *
-                                  100) /
-                                2
-                              ).toFixed(2)}
-                              %
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </Box>
-              ))}
-          </Box>
-          <Box>
-            Total games per character:{" "}
-            {popularity &&
-              (popularity.per_character_total * 2)
-                .toString()
-                .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-          </Box>
-        </Box>
-        <Box>
-          <Typography>Statistics are updated once a day.</Typography>
-          {popularity && (
-            <Typography variant="body1">
-              Last updated: {Utils.formatUTCToLocal(popularity.last_update)}
-            </Typography>
-          )}
-        </Box>
-      </Box>
+      <title>Popularity | Puddle Farm</title>
+      <Suspense
+        fallback={
+          <CircularProgress
+            size={60}
+            variant="indeterminate"
+            disableShrink={true}
+            sx={{ position: "absolute", top: "-1px", color: "white" }}
+          />
+        }
+      >
+        <PopularityContent data={popularityPromise} />
+      </Suspense>
     </>
   );
 };

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -9,111 +9,131 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Suspense, use, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
 import type { PlayerSearchResponse } from "../interfaces/API";
 import { JSONParse } from "../utils/JSONParse";
 import { Utils } from "../utils/Utils";
 
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+
+function fetchSearchResults(
+  q: string | undefined,
+  exact: string | undefined,
+): Promise<{ results: PlayerSearchResponse[] }> {
+  if (!q) return Promise.resolve({ results: [] });
+
+  const isExact = exact === "exact" ? "true" : "false";
+  const params = new URLSearchParams({ search_string: q, exact: isExact });
+
+  return fetch(`${API_ENDPOINT}/player/search?${params.toString()}`)
+    .then((res) => res.text())
+    .then((body) => {
+      const parsed = JSONParse(body) as { results: PlayerSearchResponse[] };
+      return parsed;
+    })
+    .catch(() => ({ results: [] }));
+}
+
+interface SearchResultsProps {
+  resultsPromise: Promise<{ results: PlayerSearchResponse[] }>;
+}
+
+const SearchResultsLoader = ({
+  search_string,
+  exact,
+}: {
+  search_string: string | undefined;
+  exact: string | undefined;
+}) => {
+  const [resultsPromise] = useState(() =>
+    fetchSearchResults(search_string, exact),
+  );
+  return (
+    <Suspense fallback={<CircularProgress size={60} />}>
+      <SearchResults resultsPromise={resultsPromise} />
+    </Suspense>
+  );
+};
+
+const SearchResults = ({ resultsPromise }: SearchResultsProps) => {
+  const data = use(resultsPromise);
+  const players = data.results ?? [];
+
+  if (players.length === 0) {
+    return (
+      <Box sx={{ m: 4 }}>
+        <Typography align="center">No results found.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ m: 4, maxWidth: "700px" }}>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Player</TableCell>
+              <TableCell>Character</TableCell>
+              <TableCell>Rating</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {players.map((player) => (
+              <TableRow key={`${player.id}-${player.char_short}`}>
+                <TableCell>
+                  <Button
+                    component={Link}
+                    to={`/player/${player.id}/${player.char_short}`}
+                  >
+                    {player.name}
+                  </Button>
+                </TableCell>
+                <TableCell>{player.char_short}</TableCell>
+                <TableCell>
+                  {Utils.displayRankIcon(player.rating, "32px")}
+                  <Box component={"span"}>
+                    {Utils.displayRating(player.rating)}
+                  </Box>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
 const Search = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
-
-  const _navigate = useNavigate();
-
   const { search_string, exact } = useParams();
 
-  const [results, setResults] = useState<PlayerSearchResponse[]>([]);
-
-  const [loading, setLoading] = useState(true);
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger only
   useEffect(() => {
-    document.title = "Search Results | Puddle Farm";
-    window.scrollTo(0, 0);
-
-    const fetchResults = async () => {
-      setLoading(true);
-      try {
-        const url =
-          API_ENDPOINT +
-          "/player/search?" +
-          "search_string=" +
-          search_string +
-          "&exact=" +
-          (exact && exact === "exact" ? "true" : "false");
-        const response = await fetch(url);
-
-        const _result = await response.text().then((body) => {
-          const parsed = JSONParse(body);
-
-          setResults(parsed.results);
-
-          return parsed;
-        });
-
-        setLoading(false);
-      } catch (error) {
-        console.error("Error fetching player data:", error);
-      }
-    };
-
-    fetchResults();
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, [search_string, exact]);
 
   return (
     <>
+      <title>Search Results | Puddle Farm</title>
       <AppBar
         position="static"
         style={{ backgroundImage: "none" }}
         sx={{ backgroundColor: "secondary.main" }}
       >
-        {loading ? (
-          <CircularProgress
-            size={60}
-            variant="indeterminate"
-            disableShrink={true}
-            sx={{ position: "absolute", top: "-1px", color: "white" }}
-          />
-        ) : null}
         <Box sx={{ minHeight: 100, paddingTop: "30px" }}>
           <Typography align="center" variant="pageHeader">
             Search Results
           </Typography>
         </Box>
       </AppBar>
-      <Box sx={{ m: 4, maxWidth: "700px" }}>
-        <TableContainer component={Paper}>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Player</TableCell>
-                <TableCell>Character</TableCell>
-                <TableCell>Rating</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {results.map((player) => (
-                <TableRow key={`${player.id}-${player.char_short}`}>
-                  <TableCell>
-                    <Button
-                      component={Link}
-                      to={`/player/${player.id}/${player.char_short}`}
-                    >
-                      {player.name}
-                    </Button>
-                  </TableCell>
-                  <TableCell>{player.char_short}</TableCell>
-                  <TableCell>
-                    {Utils.displayRankIcon(player.rating, "32px")}
-                    <Box component={"span"}>
-                      {Utils.displayRating(player.rating)}
-                    </Box>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Box>
+
+      <SearchResultsLoader
+        key={`${search_string}-${exact}`}
+        search_string={search_string}
+        exact={exact}
+      />
     </>
   );
 };

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -9,87 +9,40 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Suspense, use, useEffect, useState } from "react";
 import type { StatsResponse } from "../interfaces/API";
 import { JSONParse } from "../utils/JSONParse";
 import { Utils } from "./../utils/Utils";
 
-const Stats = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
 
-  const _navigate = useNavigate();
+function fetchStats(): Promise<StatsResponse | undefined> {
+  return fetch(`${API_ENDPOINT}/stats`)
+    .then((res) => res.text())
+    .then((body) => JSONParse(body) as StatsResponse)
+    .catch(() => undefined);
+}
 
-  const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState<StatsResponse>();
-  const [health, setHealth] = useState<string>("");
+function fetchHealth(): Promise<string> {
+  return fetch(`${API_ENDPOINT}/health`)
+    .then(async (res) => {
+      if (res.ok) return await res.text();
+      return `Error! ${await res.text()}`;
+    })
+    .catch(() => "");
+}
 
-  useEffect(() => {
-    document.title = "Stats | Puddle Farm";
-    window.scrollTo(0, 0);
+const StatsTables = ({
+  data,
+}: {
+  data: Promise<StatsResponse | undefined>;
+}) => {
+  const stats = use(data);
 
-    const fetchResults = async () => {
-      setLoading(true);
-      try {
-        const url = `${API_ENDPOINT}/stats`;
-        const response = await fetch(url);
-
-        const _result = await response.text().then((body) => {
-          const parsed = JSONParse(body);
-
-          setStats(parsed);
-
-          return parsed;
-        });
-
-        setLoading(false);
-
-        const health_url = `${API_ENDPOINT}/health`;
-
-        const health_response = await fetch(health_url);
-
-        if (health_response.status === 200) {
-          const result = await health_response.text().then((body) => {
-            return body;
-          });
-
-          setHealth(result);
-        } else if (health_response.status === 500) {
-          const result = await health_response.text().then((body) => {
-            return body;
-          });
-
-          setHealth(`Error! ${result}`);
-        }
-      } catch (error) {
-        console.error("Error fetching player data:", error);
-      }
-    };
-
-    fetchResults();
-  }, []);
+  if (!stats) return null;
 
   return (
     <>
-      <AppBar
-        position="static"
-        style={{ backgroundImage: "none" }}
-        sx={{ backgroundColor: "secondary.main" }}
-      >
-        {loading ? (
-          <CircularProgress
-            size={60}
-            variant="indeterminate"
-            disableShrink={true}
-            sx={{ position: "absolute", top: "-1px", color: "white" }}
-          />
-        ) : null}
-        <Box sx={{ minHeight: 100, paddingTop: "30px" }}>
-          <Typography align="center" variant="pageHeader">
-            Stats
-          </Typography>
-        </Box>
-      </AppBar>
       <Box sx={{ m: 4, maxWidth: "700px" }}>
         <Typography sx={{ my: 3 }} variant="h5">
           Players
@@ -107,38 +60,22 @@ const Stats = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {stats ? (
-                <TableRow>
-                  <TableCell>
-                    {Utils.formatUTCToLocal(stats.timestamp)}
-                  </TableCell>
-                  <TableCell>
-                    {stats.total_players
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_month_players
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_week_players
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_day_players
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_hour_players
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                </TableRow>
-              ) : null}
+              <TableRow>
+                <TableCell>{Utils.formatUTCToLocal(stats.timestamp)}</TableCell>
+                <TableCell>{Utils.formatNumber(stats.total_players)}</TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_month_players)}
+                </TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_week_players)}
+                </TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_day_players)}
+                </TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_hour_players)}
+                </TableCell>
+              </TableRow>
             </TableBody>
           </Table>
         </TableContainer>
@@ -160,38 +97,20 @@ const Stats = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {stats ? (
-                <TableRow>
-                  <TableCell>
-                    {Utils.formatUTCToLocal(stats.timestamp)}
-                  </TableCell>
-                  <TableCell>
-                    {stats.total_games
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_month_games
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_week_games
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_day_games
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                  <TableCell>
-                    {stats.one_hour_games
-                      .toString()
-                      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
-                  </TableCell>
-                </TableRow>
-              ) : null}
+              <TableRow>
+                <TableCell>{Utils.formatUTCToLocal(stats.timestamp)}</TableCell>
+                <TableCell>{Utils.formatNumber(stats.total_games)}</TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_month_games)}
+                </TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_week_games)}
+                </TableCell>
+                <TableCell>{Utils.formatNumber(stats.one_day_games)}</TableCell>
+                <TableCell>
+                  {Utils.formatNumber(stats.one_hour_games)}
+                </TableCell>
+              </TableRow>
             </TableBody>
           </Table>
         </TableContainer>
@@ -199,13 +118,61 @@ const Stats = () => {
           Statistics are updated once an hour.
         </Typography>
       </Box>
+    </>
+  );
+};
+
+const HealthDisplay = ({ data }: { data: Promise<string> }) => {
+  const health = use(data);
+
+  if (!health) return null;
+
+  return (
+    <>
+      <Box component="span">Health: </Box>
+      <Box component="span">{health}</Box>
+    </>
+  );
+};
+
+const Stats = () => {
+  const [statsPromise] = useState(() => fetchStats());
+  const [healthPromise] = useState(() => fetchHealth());
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <>
+      <title>Stats | Puddle Farm</title>
+      <AppBar
+        position="static"
+        style={{ backgroundImage: "none" }}
+        sx={{ backgroundColor: "secondary.main" }}
+      >
+        <Box sx={{ minHeight: 100, paddingTop: "30px" }}>
+          <Typography align="center" variant="pageHeader">
+            Stats
+          </Typography>
+        </Box>
+      </AppBar>
+      <Suspense
+        fallback={
+          <CircularProgress
+            size={60}
+            variant="indeterminate"
+            disableShrink={true}
+            sx={{ position: "absolute", top: "-1px", color: "white" }}
+          />
+        }
+      >
+        <StatsTables data={statsPromise} />
+      </Suspense>
       <Box sx={{ m: 4 }}>
-        {health ? (
-          <>
-            <Box component="span">Health: </Box>
-            <Box component="span">{health}</Box>
-          </>
-        ) : null}
+        <Suspense fallback={null}>
+          <HealthDisplay data={healthPromise} />
+        </Suspense>
       </Box>
     </>
   );

--- a/frontend/src/utils/Utils.jsx
+++ b/frontend/src/utils/Utils.jsx
@@ -1,6 +1,8 @@
 import { Typography } from "@mui/material";
 import { StorageUtils } from "./Storage";
 
+const numberFormatter = new Intl.NumberFormat("en-US");
+
 const IMPERIUS_SPRITE = {
   spriteX: 3,
   spriteY: 5,
@@ -101,6 +103,7 @@ const rankThresholds = [
 ];
 
 const Utils = {
+  formatNumber: (n) => numberFormatter.format(n),
   getRankThresholds: () => rankThresholds,
   getRankSprite: (rating) => {
     for (const threshold of rankThresholds) {


### PR DESCRIPTION
## Summary

- Replace `useEffect`+`fetch`+manual `loading` state with React 19's `use()` + `Suspense` on 5 pages: `About`, `Popularity`, `Matchup`, `Search`, `Stats`
- Each page splits into a parent (creates the Promise, owns the `Suspense` boundary) and a content component (`use()`s the Promise, renders the UI) — see #22 for why this split is required, not stylistic
- `Search` keeps its param-dependent refetch by keying the Promise-owning component on the search params, outside the `Suspense` boundary
- `Stats` splits `stats` and `health` into two independent Promises/Suspense boundaries, matching the original code's implicit priority (stats blocked the page, health loaded silently in the background)
- Drive-by: added `Utils.formatNumber` (backed by `Intl.NumberFormat`) to replace a regex-based thousands-separator (`.replace(/\B(?=(\d{3})+(?!\d))/g, ",")`) duplicated across `Stats.tsx` (10 call sites) and `Popularity.tsx` (2 call sites)
- This is a pilot for the convention proposed in #22 — feedback welcome there before applying the same pattern to the remaining pages

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm run check` (biome) — no errors
- [x] Manually verified each page in browser (network tab checked for the request-storm failure mode described in #22)

## Not in scope

- `Distribution.tsx`, `Legend.tsx`, `TopGlobal.tsx`, `TopPlayer.tsx` — see #22 for why each is deferred

Refs #22