### PR TITLE
refactor(frontend): type-safe character theme registry

### DIFF
--- a/frontend/src/components/ThemeManager.tsx
+++ b/frontend/src/components/ThemeManager.tsx
@@ -1,10 +1,14 @@
 import { ThemeProvider } from "@mui/material/styles";
 import { type ReactNode, useEffect, useState } from "react";
 import { StorageUtils } from "../utils/Storage";
-import Themes from "../utils/Themes";
+import Themes, {
+  defaultCharacterName,
+  defaultTheme,
+  isCharacterName,
+} from "../utils/Themes";
 
 const ThemeManager = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState("Sol");
+  const [theme, setTheme] = useState<string>(defaultCharacterName);
 
   useEffect(() => {
     const theme = StorageUtils.getTheme();
@@ -12,11 +16,17 @@ const ThemeManager = ({ children }: { children: ReactNode }) => {
     if (theme) {
       setTheme(theme);
     } else {
-      setTheme("Sol");
+      setTheme(defaultCharacterName);
     }
   }, []);
 
-  return <ThemeProvider theme={Themes.get(theme)}>{children}</ThemeProvider>;
+  return (
+    <ThemeProvider
+      theme={isCharacterName(theme) ? Themes[theme] : defaultTheme}
+    >
+      {children}
+    </ThemeProvider>
+  );
 };
 
 export default ThemeManager;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -11,9 +11,9 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import type { SettingsResponse } from "../interfaces/API";
 import { type StorageOptions, StorageUtils } from "./../utils/Storage";
-import Themes from "./../utils/Themes";
+import { characterNames } from "./../utils/Themes";
 
-const themes = Array.from(Themes.keys());
+const themes = characterNames;
 
 const Settings = () => {
   const _API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;

--- a/frontend/src/utils/Themes.tsx
+++ b/frontend/src/utils/Themes.tsx
@@ -1,4 +1,4 @@
-import { createTheme } from "@mui/material";
+import { createTheme, type Theme } from "@mui/material";
 
 declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
@@ -10,22 +10,41 @@ declare module "@mui/material/Typography" {
   }
 }
 
-const Themes = new Map();
+export type CharacterName =
+  | "Sol"
+  | "Ky"
+  | "Ramlethal"
+  | "Nagoriyuki"
+  | "Bridget"
+  | "Bedman?"
+  | "Johnny";
 
-Themes.set(
-  "Sol",
-  createTheme({
+type HexColor = `#${string}`;
+type ThemeColor = HexColor | "white" | "black" | `rgba(${string})`;
+
+interface CharacterThemeConfig {
+  name: CharacterName;
+  primaryMain: HexColor;
+  secondaryMain: HexColor;
+  backgroundDefault: HexColor;
+  playerNameColor: ThemeColor;
+  pageHeaderColor: ThemeColor;
+  platformBg: HexColor;
+  charRankBg: HexColor;
+  globalRankBg: HexColor;
+  globalRankColor: ThemeColor;
+  buttonColor: HexColor;
+  appBarBg: HexColor;
+  dialogBg: HexColor;
+}
+
+function createCharacterTheme(config: CharacterThemeConfig): Theme {
+  return createTheme({
     palette: {
       mode: "dark",
-      primary: {
-        main: "#D2B45E",
-      },
-      secondary: {
-        main: "#9B3725",
-      },
-      background: {
-        default: "#262A2C",
-      },
+      primary: { main: config.primaryMain },
+      secondary: { main: config.secondaryMain },
+      background: { default: config.backgroundDefault },
     },
     components: {
       MuiTypography: {
@@ -33,9 +52,9 @@ Themes.set(
           root: {
             variants: [
               {
-                props: { variant: "playerName" }, //Name on player page
+                props: { variant: "playerName" },
                 style: {
-                  color: "white",
+                  color: config.playerNameColor,
                   padding: "5px",
                   paddingRight: "12px",
                   paddingLeft: "12px",
@@ -47,14 +66,14 @@ Themes.set(
                 style: {
                   display: "block",
                   fontSize: 34,
-                  color: "white",
+                  color: config.pageHeaderColor,
                 },
               },
               {
                 props: { variant: "platform" },
                 style: {
                   fontSize: ".8rem",
-                  backgroundColor: "#363636",
+                  backgroundColor: config.platformBg,
                   color: "white",
                   borderRadius: "8px",
                   padding: "8px 10px",
@@ -68,7 +87,7 @@ Themes.set(
                 props: { variant: "char_rank" },
                 style: {
                   fontSize: ".8rem",
-                  backgroundColor: "#9B3725",
+                  backgroundColor: config.charRankBg,
                   color: "white",
                   fontWeight: "bold",
                   borderRadius: "8px",
@@ -83,8 +102,8 @@ Themes.set(
                 props: { variant: "global_rank" },
                 style: {
                   fontSize: ".8rem",
-                  backgroundColor: "#FFB42C",
-                  color: "rgba(0, 0, 0, 0.7)",
+                  backgroundColor: config.globalRankBg,
+                  color: config.globalRankColor,
                   fontWeight: "bold",
                   borderRadius: "8px",
                   padding: "8px 10px",
@@ -101,706 +120,147 @@ Themes.set(
       MuiButton: {
         styleOverrides: {
           root: {
-            color: "#FFB42C",
+            color: config.buttonColor,
             borderWidth: "4px",
             textTransform: "none",
           },
         },
       },
       MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#2E2C2F",
-          },
-        },
+        styleOverrides: { root: { backgroundColor: config.appBarBg } },
       },
       MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#171717",
-          },
-        },
+        styleOverrides: { paper: { background: config.dialogBg } },
       },
     },
-  }),
+  });
+}
+
+const characterThemeConfigs: CharacterThemeConfig[] = [
+  {
+    name: "Sol",
+    primaryMain: "#D2B45E",
+    secondaryMain: "#9B3725",
+    backgroundDefault: "#262A2C",
+    playerNameColor: "white",
+    pageHeaderColor: "white",
+    platformBg: "#363636",
+    charRankBg: "#9B3725",
+    globalRankBg: "#FFB42C",
+    globalRankColor: "rgba(0, 0, 0, 0.7)",
+    buttonColor: "#FFB42C",
+    appBarBg: "#2E2C2F",
+    dialogBg: "#171717",
+  },
+  {
+    name: "Ky",
+    primaryMain: "#217DBB",
+    secondaryMain: "#DDDBD5",
+    backgroundDefault: "#282E30",
+    playerNameColor: "black",
+    pageHeaderColor: "#217DBB",
+    platformBg: "#363636",
+    charRankBg: "#217DBB",
+    globalRankBg: "#CF8545",
+    globalRankColor: "rgba(0, 0, 0, 0.7)",
+    buttonColor: "#CF8545",
+    appBarBg: "#217DBB",
+    dialogBg: "#282E30",
+  },
+  {
+    name: "Ramlethal",
+    primaryMain: "#611A16",
+    secondaryMain: "#E4E1DA",
+    backgroundDefault: "#383733",
+    playerNameColor: "black",
+    pageHeaderColor: "#383733",
+    platformBg: "#383733",
+    charRankBg: "#611A16",
+    globalRankBg: "#A4FD33",
+    globalRankColor: "rgba(0, 0, 0, 0.7)",
+    buttonColor: "#A4FD33",
+    appBarBg: "#611A16",
+    dialogBg: "#383733",
+  },
+  {
+    name: "Nagoriyuki",
+    primaryMain: "#60304f",
+    secondaryMain: "#DDDBD5",
+    backgroundDefault: "#282E30",
+    playerNameColor: "black",
+    pageHeaderColor: "#DA2A46",
+    platformBg: "#363636",
+    charRankBg: "#60304f",
+    globalRankBg: "#DA2A46",
+    globalRankColor: "rgba(0, 0, 0, 0.7)",
+    buttonColor: "#DA2A46",
+    appBarBg: "#60304f",
+    dialogBg: "#282E30",
+  },
+  {
+    name: "Bridget",
+    primaryMain: "#799BB6",
+    secondaryMain: "#799BB6",
+    backgroundDefault: "#35312E",
+    playerNameColor: "white",
+    pageHeaderColor: "#D6D4CE",
+    platformBg: "#383733",
+    charRankBg: "#5777A3",
+    globalRankBg: "#A94F44",
+    globalRankColor: "rgba(0, 0, 0, 0.7)",
+    buttonColor: "#F5C74C",
+    appBarBg: "#5777A3",
+    dialogBg: "#383733",
+  },
+  {
+    name: "Bedman?",
+    primaryMain: "#471d37",
+    secondaryMain: "#A83B5E",
+    backgroundDefault: "#171717",
+    playerNameColor: "white",
+    pageHeaderColor: "white",
+    platformBg: "#363636",
+    charRankBg: "#D02F28",
+    globalRankBg: "#471d37",
+    globalRankColor: "white",
+    buttonColor: "#D02F28",
+    appBarBg: "#471d37",
+    dialogBg: "#171717",
+  },
+  {
+    name: "Johnny",
+    primaryMain: "#927757",
+    secondaryMain: "#848280",
+    backgroundDefault: "#464541",
+    playerNameColor: "white",
+    pageHeaderColor: "#D6D4CE",
+    platformBg: "#383733",
+    charRankBg: "#353235",
+    globalRankBg: "#C4A160",
+    globalRankColor: "rgba(0, 0, 0, 0.7)",
+    buttonColor: "#C4A160",
+    appBarBg: "#353235",
+    dialogBg: "#383733",
+  },
+];
+
+const Themes = Object.fromEntries(
+  characterThemeConfigs.map((config) => [
+    config.name,
+    createCharacterTheme(config),
+  ]),
+) as Record<CharacterName, Theme>;
+
+export const defaultCharacterName: CharacterName = "Sol";
+
+export const defaultTheme = Themes[defaultCharacterName];
+
+export const characterNames: CharacterName[] = characterThemeConfigs.map(
+  (config) => config.name,
 );
 
-Themes.set(
-  "Ky",
-  createTheme({
-    palette: {
-      mode: "dark",
-      primary: {
-        main: "#217DBB",
-      },
-      secondary: {
-        main: "#DDDBD5",
-      },
-      background: {
-        default: "#282E30",
-      },
-    },
-    components: {
-      MuiTypography: {
-        styleOverrides: {
-          root: {
-            variants: [
-              {
-                props: { variant: "playerName" },
-                style: {
-                  color: "black",
-                  padding: "5px",
-                  paddingRight: "12px",
-                  paddingLeft: "12px",
-                  display: "inline-block",
-                },
-              },
-              {
-                props: { variant: "pageHeader" },
-                style: {
-                  display: "block",
-                  fontSize: 34,
-                  color: "#217DBB",
-                },
-              },
-              {
-                props: { variant: "platform" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#363636",
-                  color: "white",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "char_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#217DBB",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "global_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#CF8545",
-                  color: "rgba(0, 0, 0, 0.7)",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-            ],
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            color: "#CF8545",
-            borderWidth: "4px",
-            textTransform: "none",
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#217DBB",
-          },
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#282E30",
-          },
-        },
-      },
-    },
-  }),
-);
-
-Themes.set(
-  "Ramlethal",
-  createTheme({
-    palette: {
-      mode: "dark",
-      primary: {
-        main: "#611A16", //Mostly just button border, also alias box background
-      },
-      secondary: {
-        main: "#E4E1DA", //Header (not appbar)
-      },
-      background: {
-        default: "#383733", //Main page background
-      },
-    },
-    components: {
-      MuiTypography: {
-        styleOverrides: {
-          root: {
-            variants: [
-              {
-                props: { variant: "playerName" },
-                style: {
-                  color: "black",
-                  padding: "5px",
-                  paddingRight: "12px",
-                  paddingLeft: "12px",
-                  display: "inline-block",
-                },
-              },
-              {
-                props: { variant: "pageHeader" },
-                style: {
-                  display: "block",
-                  fontSize: 34,
-                  color: "#383733", //Page header text color
-                },
-              },
-              {
-                props: { variant: "platform" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#383733",
-                  color: "white",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "char_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#611A16",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "global_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#A4FD33",
-                  color: "rgba(0, 0, 0, 0.7)",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-            ],
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            color: "#A4FD33",
-            borderWidth: "4px", //Only applies to 'outlined' variant
-            textTransform: "none",
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#611A16",
-          },
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#383733",
-          },
-        },
-      },
-    },
-  }),
-);
-
-Themes.set(
-  "Nagoriyuki",
-  createTheme({
-    palette: {
-      mode: "dark",
-      primary: {
-        main: "#60304f",
-      },
-      secondary: {
-        main: "#DDDBD5",
-      },
-      background: {
-        default: "#282E30",
-      },
-    },
-    components: {
-      MuiTypography: {
-        styleOverrides: {
-          root: {
-            variants: [
-              {
-                props: { variant: "playerName" },
-                style: {
-                  color: "black",
-                  padding: "5px",
-                  paddingRight: "12px",
-                  paddingLeft: "12px",
-                  display: "inline-block",
-                },
-              },
-              {
-                props: { variant: "pageHeader" },
-                style: {
-                  display: "block",
-                  fontSize: 34,
-                  color: "#DA2A46",
-                },
-              },
-              {
-                props: { variant: "platform" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#363636",
-                  color: "white",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "char_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#60304f",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "global_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#DA2A46",
-                  color: "rgba(0, 0, 0, 0.7)",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-            ],
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            color: "#DA2A46",
-            borderWidth: "4px",
-            textTransform: "none",
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#60304f",
-          },
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#282E30",
-          },
-        },
-      },
-    },
-  }),
-);
-
-Themes.set(
-  "Bridget",
-  createTheme({
-    palette: {
-      mode: "dark",
-      primary: {
-        main: "#799BB6", //Mostly just button border, also alias box background
-      },
-      secondary: {
-        main: "#799BB6", //Header (not appbar)
-      },
-      background: {
-        default: "#35312E", //Main page background
-      },
-    },
-    components: {
-      MuiTypography: {
-        styleOverrides: {
-          root: {
-            variants: [
-              {
-                props: { variant: "playerName" },
-                style: {
-                  color: "white",
-                  padding: "5px",
-                  paddingRight: "12px",
-                  paddingLeft: "12px",
-                  display: "inline-block",
-                },
-              },
-              {
-                props: { variant: "pageHeader" },
-                style: {
-                  display: "block",
-                  fontSize: 34,
-                  color: "#D6D4CE", //Page header text color
-                },
-              },
-              {
-                props: { variant: "platform" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#383733",
-                  color: "white",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "char_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#5777A3",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "global_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#A94F44",
-                  color: "rgba(0, 0, 0, 0.7)",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-            ],
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            color: "#F5C74C",
-            borderWidth: "4px", //Only applies to 'outlined' variant
-            textTransform: "none",
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#5777A3",
-          },
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#383733",
-          },
-        },
-      },
-    },
-  }),
-);
-
-Themes.set(
-  "Bedman?",
-  createTheme({
-    palette: {
-      mode: "dark",
-      primary: {
-        main: "#471d37",
-      },
-      secondary: {
-        main: "#A83B5E",
-      },
-      background: {
-        default: "#171717",
-      },
-    },
-    components: {
-      MuiTypography: {
-        styleOverrides: {
-          root: {
-            variants: [
-              {
-                props: { variant: "playerName" },
-                style: {
-                  color: "white",
-                  padding: "5px",
-                  paddingRight: "12px",
-                  paddingLeft: "12px",
-                  display: "inline-block",
-                },
-              },
-              {
-                props: { variant: "pageHeader" },
-                style: {
-                  display: "block",
-                  fontSize: 34,
-                  color: "white",
-                },
-              },
-              {
-                props: { variant: "platform" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#363636",
-                  color: "white",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "char_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#D02F28",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "global_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#471d37",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-            ],
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            color: "#D02F28",
-            borderWidth: "4px",
-            textTransform: "none",
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#471d37",
-          },
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#171717",
-          },
-        },
-      },
-    },
-  }),
-);
-
-Themes.set(
-  "Johnny",
-  createTheme({
-    palette: {
-      mode: "dark",
-      primary: {
-        main: "#927757", //Mostly just button border, also alias box background
-      },
-      secondary: {
-        main: "#848280", //Header (not appbar)
-      },
-      background: {
-        default: "#464541", //Main page background
-      },
-    },
-    components: {
-      MuiTypography: {
-        styleOverrides: {
-          root: {
-            variants: [
-              {
-                props: { variant: "playerName" },
-                style: {
-                  color: "white",
-                  padding: "5px",
-                  paddingRight: "12px",
-                  paddingLeft: "12px",
-                  display: "inline-block",
-                },
-              },
-              {
-                props: { variant: "pageHeader" },
-                style: {
-                  display: "block",
-                  fontSize: 34,
-                  color: "#D6D4CE", //Page header text color
-                },
-              },
-              {
-                props: { variant: "platform" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#383733",
-                  color: "white",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "char_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#353235",
-                  color: "white",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-              {
-                props: { variant: "global_rank" },
-                style: {
-                  fontSize: ".8rem",
-                  backgroundColor: "#C4A160",
-                  color: "rgba(0, 0, 0, 0.7)",
-                  fontWeight: "bold",
-                  borderRadius: "8px",
-                  padding: "8px 10px",
-                  display: "inline-block",
-                  marginLeft: "8px",
-                  top: "-4px",
-                  position: "relative",
-                },
-              },
-            ],
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            color: "#C4A160",
-            borderWidth: "4px", //Only applies to 'outlined' variant
-            textTransform: "none",
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: "#353235",
-          },
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            background: "#383733",
-          },
-        },
-      },
-    },
-  }),
-);
+export function isCharacterName(name: string): name is CharacterName {
+  return characterThemeConfigs.some((config) => config.name === name);
+}
 
 export default Themes;


### PR DESCRIPTION
## Summary

Replace the `Map`-based `Themes` registry in `utils/Themes.tsx` with a
typed factory keyed by a `CharacterName` string union. Each character's
theme is now declared as a plain config object (colors only) fed through
one `createCharacterTheme()` function, instead of a full `createTheme()`
call duplicated per character.

- Add `CharacterName` union type and `isCharacterName()` type guard
- `ThemeManager`/`Settings` now use the guard instead of an unchecked
  `Themes.get(name)` lookup, with a documented fallback to the default
  theme for unrecognized names
- No visual changes — colors and MUI overrides are unchanged, just
  restructured into data instead of duplicated `createTheme()` calls

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm run check` (biome) — no errors
- [x] Manually verified theme switching across all 7 characters in browser