### PR TITLE
fix(frontend): fix Matchup table sticky header/column z-index layering

### DIFF
--- a/frontend/src/pages/Matchup.tsx
+++ b/frontend/src/pages/Matchup.tsx
@@ -94,7 +94,9 @@ const MatchupTable = ({
         <Table stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ position: "sticky", top: 0, zIndex: 1 }}>
+              <TableCell
+                sx={{ position: "sticky", top: 0, left: 0, zIndex: 3 }}
+              >
                 <TableSortLabel
                   active={orderBy === "character"}
                   direction={orderBy === "character" ? order : "asc"}
@@ -110,7 +112,7 @@ const MatchupTable = ({
                     sx={{
                       position: "sticky",
                       top: 0,
-                      zIndex: 1,
+                      zIndex: 2,
                       backgroundColor: hoveredCol === index ? "grey" : "black",
                     }}
                   >


### PR DESCRIPTION
## Summary

Fixes the z-index layering between the sticky header row and the sticky
left column in the Matchup table, per #25.

- Corner cell (Character header): add missing `left: 0` sticky offset, `zIndex: 1` → `3`
- Other header cells: `zIndex: 1` → `2`
- Body left-column cells: unchanged, already correctly the lowest sticky layer at `zIndex: 1`

Layering is now: corner (top+left) > header row (top) > sticky column (left) > regular cells.

## Test plan

- [x] `npm run typecheck` — no errors
- [x] Manually verified in browser: vertical scroll (header stays above the
      sticky column) and horizontal scroll (corner cell stays above other
      header cells)

Fixes #25