### PR TITLE
refactor(frontend): migrate TopGlobal/TopPlayer to hooks + Suspense

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Box, Button, CssBaseline, Link, Typography } from "@mui/material";
 import { Route, Routes } from "react-router-dom";
 import NavBar from "./components/NavBar";
 import ThemeManager from "./components/ThemeManager";
+import { CharacterNamesProvider } from "./hooks/useCharacterNames";
 import DiscordIcon from "./images/discord-mark-white.svg?react";
 import GitHubIcon from "./images/github-mark-white.svg?react";
 import PatreonIcon from "./images/patreon-mark-white.svg?react";
@@ -26,32 +27,37 @@ import TopPlayer from "./pages/TopPlayer";
 const App = () => {
   return (
     <ThemeManager>
-      <CssBaseline enableColorScheme />
-      <NavBar />
-      <Box sx={{ display: "block" }}>
-        <Routes>
-          <Route path="/" element={<Legend />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/top_global/:count?/:offset?" element={<TopGlobal />} />
-          <Route
-            path="/top/:char_short/:count?/:offset?"
-            element={<TopPlayer />}
-          />
-          <Route
-            path="/player/:player_id/:char_short?/:count?/:offset?"
-            element={<Player />}
-          />
-          <Route path="/search" element={<Search />} />
-          <Route path="/stats" element={<Stats />} />
-          <Route path="/popularity" element={<Popularity />} />
-          <Route path="/matchup" element={<Matchup />} />
-          <Route path="/distribution" element={<Distribution />} />
-          <Route path="/terms" element={<Terms />} />
-          <Route path="/legend" element={<Legend />} />
-          <Route path="*" element={<Legend />} />
-        </Routes>
-      </Box>
+      <CharacterNamesProvider>
+        <CssBaseline enableColorScheme />
+        <NavBar />
+        <Box sx={{ display: "block" }}>
+          <Routes>
+            <Route path="/" element={<Legend />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route
+              path="/top_global/:count?/:offset?"
+              element={<TopGlobal />}
+            />
+            <Route
+              path="/top/:char_short/:count?/:offset?"
+              element={<TopPlayer />}
+            />
+            <Route
+              path="/player/:player_id/:char_short?/:count?/:offset?"
+              element={<Player />}
+            />
+            <Route path="/search" element={<Search />} />
+            <Route path="/stats" element={<Stats />} />
+            <Route path="/popularity" element={<Popularity />} />
+            <Route path="/matchup" element={<Matchup />} />
+            <Route path="/distribution" element={<Distribution />} />
+            <Route path="/terms" element={<Terms />} />
+            <Route path="/legend" element={<Legend />} />
+            <Route path="*" element={<Legend />} />
+          </Routes>
+        </Box>
+      </CharacterNamesProvider>
       <Box
         sx={{
           display: "block",

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, test, vi } from "vitest";
+import { NotFoundError } from "../errors/NotFoundError";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+const ThrowingComponent = ({ error }: { error: Error }) => {
+  throw error;
+};
+
+describe("ErrorBoundary", () => {
+  test("renders children when there is no error", () => {
+    render(
+      <MemoryRouter>
+        <ErrorBoundary>
+          <div>content</div>
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    screen.getByText("content");
+  });
+
+  test("redirects to home when a NotFoundError is thrown", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <MemoryRouter initialEntries={["/top/SO"]}>
+        <Routes>
+          <Route path="/" element={<div>Home Page</div>} />
+          <Route
+            path="/top/:char_short"
+            element={
+              <ErrorBoundary>
+                <ThrowingComponent error={new NotFoundError()} />
+              </ErrorBoundary>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    screen.getByText("Home Page");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("shows the error message when a generic Error is thrown", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <ErrorBoundary>
+          <ThrowingComponent error={new Error("server exploded")} />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    screen.getByText("server exploded");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("falls back to a generic message when the error has no message", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <ErrorBoundary>
+          <ThrowingComponent error={new Error()} />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    screen.getByText("Could not connect to the API.");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("resets the error state and renders children again once resetKey changes", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <ErrorBoundary resetKey="a">
+          <ThrowingComponent error={new Error("boom")} />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+    screen.getByText("boom");
+
+    rerender(
+      <MemoryRouter>
+        <ErrorBoundary resetKey="b">
+          <div>recovered</div>
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    screen.getByText("recovered");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("keeps showing the error when resetKey is unchanged", () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <ErrorBoundary resetKey="a">
+          <ThrowingComponent error={new Error("boom")} />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+    screen.getByText("boom");
+
+    rerender(
+      <MemoryRouter>
+        <ErrorBoundary resetKey="a">
+          <div>should not appear</div>
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    screen.getByText("boom");
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import Typography from "@mui/material/Typography";
+import { Component, type ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { NotFoundError } from "../errors/NotFoundError";
+
+interface Props {
+  children: ReactNode;
+  resetKey?: string;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  render() {
+    const { error } = this.state;
+
+    if (error instanceof NotFoundError) {
+      return <Navigate to="/" replace />;
+    }
+
+    if (error) {
+      return (
+        <Typography color="error" align="center" sx={{ mb: 2 }}>
+          {error.message || "Could not connect to the API."}
+        </Typography>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -18,11 +18,12 @@ import {
   type MouseEvent,
   type SetStateAction,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { Link } from "react-router-dom";
+import { useCharacterNames } from "../hooks/useCharacterNames";
 import { useSearchNavigation } from "../hooks/useSearchNavigation";
-import { JSONParse } from "../utils/JSONParse";
 import { StorageUtils } from "../utils/Storage";
 
 interface Page {
@@ -43,10 +44,6 @@ const pages: Page[] = [
   { name: "Stats", link: "./stats" },
 ];
 
-function resetCharacters() {
-  pages[2].list = [];
-}
-
 function NavBar() {
   const navigateToSearch = useSearchNavigation();
 
@@ -60,7 +57,20 @@ function NavBar() {
 
   const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
 
-  const [_characters, setCharacters] = useState([]);
+  const characterNames = useCharacterNames();
+
+  const navPages = useMemo(() => {
+    const characterList = characterNames
+      ? Object.entries(characterNames).map(([charShort, charLong]) => ({
+          key: charShort,
+          name: charLong,
+          link: `/top/${charShort}`,
+        }))
+      : [];
+    return pages.map((page) =>
+      page.name === "Characters" ? { ...page, list: characterList } : page,
+    );
+  }, [characterNames]);
 
   const [healthMessage, setHealthMessage] = useState<string | null>(null);
 
@@ -85,33 +95,6 @@ function NavBar() {
   };
 
   useEffect(() => {
-    const fetchCharacterList = async () => {
-      try {
-        const response = await fetch(`${API_ENDPOINT}/characters`);
-
-        const _result = await response.text().then((body) => {
-          const parsed = JSONParse(body);
-
-          resetCharacters();
-          for (const key in parsed) {
-            if (pages[2].list) {
-              pages[2].list.push({
-                key: key,
-                name: parsed[key][1],
-                link: `/top/${parsed[key][0]}`,
-              });
-            }
-          }
-
-          setCharacters(parsed);
-
-          return parsed;
-        });
-      } catch (error) {
-        console.error("Error fetching character list:", error);
-      }
-    };
-
     const checkHealth = async () => {
       try {
         const response = await fetch(`${API_ENDPOINT}/health`);
@@ -133,7 +116,6 @@ function NavBar() {
       }
     };
 
-    fetchCharacterList();
     checkHealth();
 
     // Read preferences
@@ -207,7 +189,7 @@ function NavBar() {
               >
                 {" "}
                 {/* Mobile view - menu */}
-                {pages.map((page) =>
+                {navPages.map((page) =>
                   //If the page has a 'list' attribute that is an array, render a submenu
                   "list" in page ? (
                     <Box
@@ -274,7 +256,7 @@ function NavBar() {
             </Box>
             <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
               {/* Desktop view */}
-              {pages.map((page) =>
+              {navPages.map((page) =>
                 //If the page has a 'list' attribute that is an array, render a submenu
                 "list" in page ? (
                   <Box key={page.name}>

--- a/frontend/src/components/UpdateCountdown.test.tsx
+++ b/frontend/src/components/UpdateCountdown.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { DurationMs } from "../utils/time";
+import { ONE_DAY_MS, parseUtcTimestamp } from "../utils/time";
+import { UpdateCountdown } from "./UpdateCountdown";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("UpdateCountdown", () => {
+  test("shows the remaining time before the window elapses", () => {
+    render(
+      <UpdateCountdown
+        lastUpdateMs={parseUtcTimestamp("2025-12-31 00:00:01")}
+        intervalMs={ONE_DAY_MS}
+      />,
+    );
+    expect(screen.getByText("Next update in: 0:00:01")).toBeDefined();
+  });
+
+  test('shows "Updating..." once the window has elapsed', () => {
+    render(
+      <UpdateCountdown
+        lastUpdateMs={parseUtcTimestamp("2025-12-30 00:00:00")}
+        intervalMs={ONE_DAY_MS}
+      />,
+    );
+    expect(screen.getByText("Updating...")).toBeDefined();
+  });
+
+  test("respects a different interval, e.g. a 1-hour window", () => {
+    render(
+      <UpdateCountdown
+        lastUpdateMs={parseUtcTimestamp("2025-12-31 23:00:01")}
+        intervalMs={3600_000 as DurationMs}
+      />,
+    );
+    expect(screen.getByText("Next update in: 0:00:01")).toBeDefined();
+  });
+});

--- a/frontend/src/components/UpdateCountdown.test.tsx
+++ b/frontend/src/components/UpdateCountdown.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { DurationMs } from "../utils/time";
+import type { DurationMs, EpochMs } from "../utils/time";
 import { ONE_DAY_MS, parseUtcTimestamp } from "../utils/time";
 import { UpdateCountdown } from "./UpdateCountdown";
 
@@ -17,7 +17,7 @@ describe("UpdateCountdown", () => {
   test("shows the remaining time before the window elapses", () => {
     render(
       <UpdateCountdown
-        lastUpdateMs={parseUtcTimestamp("2025-12-31 00:00:01")}
+        lastUpdateMs={parseUtcTimestamp("2025-12-31 00:00:01") as EpochMs}
         intervalMs={ONE_DAY_MS}
       />,
     );
@@ -27,7 +27,7 @@ describe("UpdateCountdown", () => {
   test('shows "Updating..." once the window has elapsed', () => {
     render(
       <UpdateCountdown
-        lastUpdateMs={parseUtcTimestamp("2025-12-30 00:00:00")}
+        lastUpdateMs={parseUtcTimestamp("2025-12-30 00:00:00") as EpochMs}
         intervalMs={ONE_DAY_MS}
       />,
     );
@@ -37,7 +37,7 @@ describe("UpdateCountdown", () => {
   test("respects a different interval, e.g. a 1-hour window", () => {
     render(
       <UpdateCountdown
-        lastUpdateMs={parseUtcTimestamp("2025-12-31 23:00:01")}
+        lastUpdateMs={parseUtcTimestamp("2025-12-31 23:00:01") as EpochMs}
         intervalMs={3600_000 as DurationMs}
       />,
     );

--- a/frontend/src/components/UpdateCountdown.tsx
+++ b/frontend/src/components/UpdateCountdown.tsx
@@ -1,0 +1,23 @@
+import Typography from "@mui/material/Typography";
+import { useCountdown } from "../hooks/useCountdown";
+import type { DurationMs, EpochMs } from "../utils/time";
+import { addDuration } from "../utils/time";
+import { Utils } from "../utils/Utils";
+
+export const UpdateCountdown = ({
+  lastUpdateMs,
+  intervalMs,
+}: {
+  lastUpdateMs: EpochMs;
+  intervalMs: DurationMs;
+}) => {
+  const { secondsLeft } = useCountdown(addDuration(lastUpdateMs, intervalMs));
+
+  return (
+    <Typography align="left" sx={{ mb: 1 }}>
+      {secondsLeft > 0
+        ? `Next update in: ${Utils.formatCountdown(secondsLeft)}`
+        : "Updating..."}
+    </Typography>
+  );
+};

--- a/frontend/src/components/UpdateCountdown.tsx
+++ b/frontend/src/components/UpdateCountdown.tsx
@@ -14,7 +14,7 @@ export const UpdateCountdown = ({
   const { secondsLeft } = useCountdown(addDuration(lastUpdateMs, intervalMs));
 
   return (
-    <Typography align="left" sx={{ mb: 1 }}>
+    <Typography align="left" sx={{ mb: 2 }}>
       {secondsLeft > 0
         ? `Next update in: ${Utils.formatCountdown(secondsLeft)}`
         : "Updating..."}

--- a/frontend/src/errors/NotFoundError.test.ts
+++ b/frontend/src/errors/NotFoundError.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { NotFoundError } from "./NotFoundError";
+
+describe("NotFoundError", () => {
+  test("is an instance of both Error and NotFoundError", () => {
+    const error = new NotFoundError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(NotFoundError);
+  });
+});

--- a/frontend/src/errors/NotFoundError.ts
+++ b/frontend/src/errors/NotFoundError.ts
@@ -1,0 +1,1 @@
+export class NotFoundError extends Error {}

--- a/frontend/src/hooks/useCharacterNames.test.tsx
+++ b/frontend/src/hooks/useCharacterNames.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { CharacterNamesProvider, useCharacterNames } from "./useCharacterNames";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <CharacterNamesProvider>{children}</CharacterNamesProvider>;
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          ["SO", "Sol"],
+          ["KY", "Ky"],
+        ]),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useCharacterNames", () => {
+  test("returns null before the provider's fetch resolves", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+
+    const { result } = renderHook(() => useCharacterNames(), { wrapper });
+
+    expect(result.current).toBeNull();
+  });
+
+  test("returns the char_short -> char_long map once the provider's fetch resolves", async () => {
+    const { result } = renderHook(() => useCharacterNames(), { wrapper });
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(result.current).toEqual({ SO: "Sol", KY: "Ky" });
+  });
+
+  test("returns null when rendered outside a CharacterNamesProvider", () => {
+    const { result } = renderHook(() => useCharacterNames());
+
+    expect(result.current).toBeNull();
+  });
+
+  test("logs the error and keeps returning null when fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down")),
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(() => useCharacterNames(), { wrapper });
+
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+
+    expect(result.current).toBeNull();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useCharacterNames.tsx
+++ b/frontend/src/hooks/useCharacterNames.tsx
@@ -1,0 +1,41 @@
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+
+const CharacterNamesContext = createContext<Record<string, string> | null>(
+  null,
+);
+
+async function fetchCharacterNames(): Promise<Record<string, string>> {
+  const response = await fetch(`${API_ENDPOINT}/characters`);
+  const parsed = (await response.json()) as [string, string][];
+  return Object.fromEntries(parsed);
+}
+
+export function CharacterNamesProvider({ children }: { children: ReactNode }) {
+  const [names, setNames] = useState<Record<string, string> | null>(null);
+
+  useEffect(() => {
+    fetchCharacterNames()
+      .then(setNames)
+      .catch((error) => {
+        console.error("Error fetching character list:", error);
+      });
+  }, []);
+
+  return (
+    <CharacterNamesContext.Provider value={names}>
+      {children}
+    </CharacterNamesContext.Provider>
+  );
+}
+
+export function useCharacterNames(): Record<string, string> | null {
+  return useContext(CharacterNamesContext);
+}

--- a/frontend/src/hooks/useCountdown.test.ts
+++ b/frontend/src/hooks/useCountdown.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { EpochMs } from "../utils/time";
+import { useCountdown } from "./useCountdown";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useCountdown", () => {
+  test("returns seconds remaining until targetTimestamp", () => {
+    const target = (Date.now() + 10_000) as EpochMs;
+    const { result } = renderHook(() => useCountdown(target));
+    expect(result.current.secondsLeft).toBe(10);
+  });
+
+  test("counts down by 1 every second", () => {
+    const target = (Date.now() + 10_000) as EpochMs;
+    const { result } = renderHook(() => useCountdown(target));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.secondsLeft).toBe(9);
+  });
+
+  test("goes negative once the target has passed", () => {
+    const target = (Date.now() + 1000) as EpochMs;
+    const { result } = renderHook(() => useCountdown(target));
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.secondsLeft).toBe(-2);
+  });
+
+  test("clears the interval on unmount", () => {
+    const target = (Date.now() + 10_000) as EpochMs;
+    const { result, unmount } = renderHook(() => useCountdown(target));
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // secondsLeft is frozen at whatever it was before unmount; no crash means the interval was cleared.
+    expect(result.current.secondsLeft).toBe(10);
+  });
+});

--- a/frontend/src/hooks/useCountdown.ts
+++ b/frontend/src/hooks/useCountdown.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import type { EpochMs } from "../utils/time";
+
+export interface UseCountdownResult {
+  secondsLeft: number;
+}
+
+function computeSecondsLeft(targetTimestamp: EpochMs): number {
+  return Math.floor((targetTimestamp - Date.now()) / 1000);
+}
+
+export function useCountdown(targetTimestamp: EpochMs): UseCountdownResult {
+  const [secondsLeft, setSecondsLeft] = useState(() =>
+    computeSecondsLeft(targetTimestamp),
+  );
+
+  useEffect(() => {
+    setSecondsLeft(computeSecondsLeft(targetTimestamp));
+
+    const id = setInterval(() => {
+      setSecondsLeft(computeSecondsLeft(targetTimestamp));
+    }, 1000);
+
+    return () => clearInterval(id);
+  }, [targetTimestamp]);
+
+  return { secondsLeft };
+}

--- a/frontend/src/hooks/useRanking.test.tsx
+++ b/frontend/src/hooks/useRanking.test.tsx
@@ -49,6 +49,7 @@ describe("fetchRanking", () => {
                   tags: [{ tag: "Champ", style: '{"color":"red"}' }],
                 },
               ],
+              last_update: "2026-01-01 00:00:00",
             }),
           ),
       }),
@@ -56,24 +57,42 @@ describe("fetchRanking", () => {
 
     const result = await fetchRanking(config, 100, 0);
 
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("Alice");
-    expect(result[0].tags[0].style).toEqual({ color: "red" });
+    expect(result.ranks).toHaveLength(1);
+    expect(result.ranks[0].name).toBe("Alice");
+    expect(result.ranks[0].tags[0].style).toEqual({ color: "red" });
+    expect(result.lastUpdateMs).toBe(Date.parse("2026-01-01T00:00:00.000Z"));
   });
 
-  test("returns an empty array when ranks is empty", async () => {
+  test("returns an empty ranks array when ranks is empty", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         status: 200,
         ok: true,
-        text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+        text: () =>
+          Promise.resolve(JSON.stringify({ ranks: [], last_update: null })),
       }),
     );
 
     const result = await fetchRanking(config, 100, 0);
 
-    expect(result).toEqual([]);
+    expect(result.ranks).toEqual([]);
+  });
+
+  test("returns null lastUpdateMs when the response has a null last_update", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        text: () =>
+          Promise.resolve(JSON.stringify({ ranks: [], last_update: null })),
+      }),
+    );
+
+    const result = await fetchRanking(config, 100, 0);
+
+    expect(result.lastUpdateMs).toBeNull();
   });
 
   test("throws NotFoundError on a 404 response", async () => {
@@ -120,7 +139,8 @@ function stubFetchResolvedWithEmptyRanks() {
     vi.fn().mockResolvedValue({
       status: 200,
       ok: true,
-      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+      text: () =>
+        Promise.resolve(JSON.stringify({ ranks: [], last_update: null })),
     }),
   );
 }
@@ -135,7 +155,8 @@ describe("useRankingPromise", () => {
     const fetchMock = vi.fn().mockResolvedValue({
       status: 200,
       ok: true,
-      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+      text: () =>
+        Promise.resolve(JSON.stringify({ ranks: [], last_update: null })),
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -159,7 +180,8 @@ describe("useRankingPromise", () => {
     const fetchMock = vi.fn().mockResolvedValue({
       status: 200,
       ok: true,
-      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+      text: () =>
+        Promise.resolve(JSON.stringify({ ranks: [], last_update: null })),
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -185,7 +207,8 @@ describe("useRankingPromise", () => {
     const fetchMock = vi.fn().mockResolvedValue({
       status: 200,
       ok: true,
-      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+      text: () =>
+        Promise.resolve(JSON.stringify({ ranks: [], last_update: null })),
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/frontend/src/hooks/useRanking.test.tsx
+++ b/frontend/src/hooks/useRanking.test.tsx
@@ -1,0 +1,262 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { NotFoundError } from "../errors/NotFoundError";
+import {
+  computeGoToPage,
+  computeNextPage,
+  computePageInput,
+  computePrevPage,
+  computeShowNext,
+  fetchRanking,
+  useRankingPromise,
+} from "./useRanking";
+
+let mockParams: Record<string, string | undefined> = {};
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => mockParams,
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const config = {
+  buildFetchUrl: (count: number, offset: number) =>
+    `/api/top?count=${count}&offset=${offset}`,
+};
+
+describe("fetchRanking", () => {
+  test("returns parsed ranking entries with tag styles on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              ranks: [
+                {
+                  rank: 1,
+                  id: "1",
+                  name: "Alice",
+                  rating: 1500,
+                  deviation: 50,
+                  char_short: "SO",
+                  char_long: "Sol",
+                  is_legend: false,
+                  tags: [{ tag: "Champ", style: '{"color":"red"}' }],
+                },
+              ],
+            }),
+          ),
+      }),
+    );
+
+    const result = await fetchRanking(config, 100, 0);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Alice");
+    expect(result[0].tags[0].style).toEqual({ color: "red" });
+  });
+
+  test("returns an empty array when ranks is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+      }),
+    );
+
+    const result = await fetchRanking(config, 100, 0);
+
+    expect(result).toEqual([]);
+  });
+
+  test("throws NotFoundError on a 404 response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 404, ok: false }),
+    );
+
+    await expect(fetchRanking(config, 100, 0)).rejects.toThrow(NotFoundError);
+  });
+
+  test("throws an Error with the response body text on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 500,
+        ok: false,
+        text: () => Promise.resolve("server exploded"),
+      }),
+    );
+
+    await expect(fetchRanking(config, 100, 0)).rejects.toThrow(
+      "server exploded",
+    );
+  });
+
+  test("throws a generic status-based Error when the response body is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 500,
+        ok: false,
+        text: () => Promise.resolve(""),
+      }),
+    );
+
+    await expect(fetchRanking(config, 100, 0)).rejects.toThrow("Error 500");
+  });
+});
+
+function stubFetchResolvedWithEmptyRanks() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+    }),
+  );
+}
+
+describe("useRankingPromise", () => {
+  beforeEach(() => {
+    mockParams = { count: "50", offset: "0" };
+    vi.stubGlobal("scrollTo", vi.fn());
+  });
+
+  test("fetches the URL built from the initial count/offset", () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useRankingPromise(config));
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/top?count=50&offset=0");
+  });
+
+  test("returns the same promise across rerenders when params are unchanged", () => {
+    stubFetchResolvedWithEmptyRanks();
+
+    const { result, rerender } = renderHook(() => useRankingPromise(config));
+    const firstPromise = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(firstPromise);
+  });
+
+  test("creates a new promise when offset changes", () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(() => useRankingPromise(config));
+    const firstPromise = result.current;
+
+    mockParams = { count: "50", offset: "50" };
+    rerender();
+
+    expect(result.current).not.toBe(firstPromise);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("creates a new promise when the built URL changes even though count/offset stay the same", () => {
+    // Regression test: a char_short switch on TopPlayer leaves count/offset
+    // unchanged but changes the fetch URL. The cache key must track the URL,
+    // not just count/offset, or the old character's ranking keeps showing.
+    let charShort = "SO";
+    const dynamicConfig = {
+      buildFetchUrl: (count: number, offset: number) =>
+        `/api/top_char/${charShort}?count=${count}&offset=${offset}`,
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(() =>
+      useRankingPromise(dynamicConfig),
+    );
+    const firstPromise = result.current;
+
+    charShort = "KY";
+    rerender();
+
+    expect(result.current).not.toBe(firstPromise);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("computePageInput", () => {
+  test("computes the page number from offset and count", () => {
+    expect(computePageInput(50, 0)).toBe("1");
+    expect(computePageInput(50, 100)).toBe("3");
+  });
+});
+
+describe("computeShowNext", () => {
+  test("is false when fewer results than page size come back", () => {
+    expect(computeShowNext(30, 50)).toBe(false);
+  });
+
+  test("is true when a full page comes back", () => {
+    expect(computeShowNext(50, 50)).toBe(true);
+  });
+
+  test("is false when the backend's 1000-rank cap is hit, even on a full page", () => {
+    expect(computeShowNext(1000, 1000)).toBe(false);
+  });
+});
+
+describe("computePrevPage", () => {
+  test("shifts offset back by count", () => {
+    expect(computePrevPage(50, 100)).toEqual({ count: 50, offset: 50 });
+  });
+
+  test("clamps offset to 0 instead of going negative", () => {
+    expect(computePrevPage(50, 20)).toEqual({ count: 50, offset: 0 });
+  });
+
+  test("falls back to the default count when count is negative", () => {
+    expect(computePrevPage(-5, 10)).toEqual({ count: 100, offset: 15 });
+  });
+});
+
+describe("computeNextPage", () => {
+  test("shifts offset forward by count", () => {
+    expect(computeNextPage(50, 100)).toEqual({ count: 50, offset: 150 });
+  });
+});
+
+describe("computeGoToPage", () => {
+  test("computes offset from a 1-based page number", () => {
+    expect(computeGoToPage(50, 3)).toEqual({ count: 50, offset: 100 });
+  });
+
+  test("returns null for a zero page", () => {
+    expect(computeGoToPage(50, 0)).toBeNull();
+  });
+
+  test("returns null for a negative page", () => {
+    expect(computeGoToPage(50, -1)).toBeNull();
+  });
+
+  test("returns null for NaN", () => {
+    expect(computeGoToPage(50, Number.NaN)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useRanking.test.tsx
+++ b/frontend/src/hooks/useRanking.test.tsx
@@ -95,6 +95,39 @@ describe("fetchRanking", () => {
     expect(result.lastUpdateMs).toBeNull();
   });
 
+  test("returns null lastUpdateMs when last_update is absent from the response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ ranks: [] })),
+      }),
+    );
+
+    const result = await fetchRanking(config, 100, 0);
+
+    expect(result.lastUpdateMs).toBeNull();
+  });
+
+  test("returns null lastUpdateMs instead of rejecting when last_update is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ ranks: [], last_update: "not-a-date" }),
+          ),
+      }),
+    );
+
+    const result = await fetchRanking(config, 100, 0);
+
+    expect(result.lastUpdateMs).toBeNull();
+  });
+
   test("throws NotFoundError on a 404 response", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/hooks/useRanking.ts
+++ b/frontend/src/hooks/useRanking.ts
@@ -1,0 +1,202 @@
+import type React from "react";
+import { startTransition, use, useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { NotFoundError } from "../errors/NotFoundError";
+import type { PlayerRankResponse } from "../interfaces/API";
+import { JSONParse } from "../utils/JSONParse";
+
+export interface RankingTag {
+  tag: string;
+  style: React.CSSProperties;
+}
+
+export interface RankingEntry extends Omit<PlayerRankResponse, "tags"> {
+  tags: RankingTag[];
+}
+
+export interface UseRankingConfig {
+  buildFetchUrl: (count: number, offset: number) => string;
+  buildNavPath: (count: number, offset: number) => string;
+}
+
+export async function fetchRanking(
+  config: Pick<UseRankingConfig, "buildFetchUrl">,
+  count: number,
+  offset: number,
+): Promise<RankingEntry[]> {
+  const url = config.buildFetchUrl(count, offset);
+  const response = await fetch(url);
+
+  if (response.status === 404) {
+    throw new NotFoundError();
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Error ${response.status}`);
+  }
+
+  const body = await response.text();
+  const parsed = JSONParse(body) as {
+    ranks: (Omit<PlayerRankResponse, "tags"> & {
+      tags: { tag: string; style: string }[];
+    })[];
+  };
+
+  return parsed.ranks.map((entry) => ({
+    ...entry,
+    tags: entry.tags.map((tag) => ({
+      tag: tag.tag,
+      style: JSON.parse(tag.style) as React.CSSProperties,
+    })),
+  }));
+}
+
+const DEFAULT_COUNT = 100;
+
+function parseCountOffset(
+  count: string | undefined,
+  offset: string | undefined,
+): [number, number] {
+  const parsedCount = count ? parseInt(count, 10) : DEFAULT_COUNT;
+  const parsedOffset = offset ? parseInt(offset, 10) : 0;
+  return [parsedCount, parsedOffset];
+}
+
+export function useRankingPromise(
+  config: Pick<UseRankingConfig, "buildFetchUrl">,
+): Promise<RankingEntry[]> {
+  const { count, offset } = useParams();
+  const [parsedCount, parsedOffset] = parseCountOffset(count, offset);
+  const cacheKey = config.buildFetchUrl(parsedCount, parsedOffset);
+
+  const cacheRef = useRef<{
+    key: string;
+    promise: Promise<RankingEntry[]>;
+  } | null>(null);
+
+  if (!cacheRef.current || cacheRef.current.key !== cacheKey) {
+    cacheRef.current = {
+      key: cacheKey,
+      promise: fetchRanking(config, parsedCount, parsedOffset),
+    };
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger only
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [cacheKey]);
+
+  return cacheRef.current.promise;
+}
+
+export function computePageInput(count: number, offset: number): string {
+  return String(Math.floor(offset / count) + 1);
+}
+
+export function computeShowNext(rankingLength: number, count: number): boolean {
+  // backend caps a single page at 1000 ranks
+  return !(rankingLength < count || rankingLength === 1000);
+}
+
+export function computePrevPage(
+  count: number,
+  offset: number,
+): { count: number; offset: number } {
+  let navCount = count;
+  let navOffset = offset - navCount;
+  if (navCount < 0) navCount = DEFAULT_COUNT;
+  if (navOffset < 0) navOffset = 0;
+  return { count: navCount, offset: navOffset };
+}
+
+export function computeNextPage(
+  count: number,
+  offset: number,
+): { count: number; offset: number } {
+  return { count, offset: offset + count };
+}
+
+export function computeGoToPage(
+  count: number,
+  page: number,
+): { count: number; offset: number } | null {
+  if (Number.isNaN(page) || page <= 0) {
+    return null;
+  }
+  return { count, offset: (page - 1) * count };
+}
+
+export interface UseRankingResult {
+  ranking: RankingEntry[];
+  showNext: boolean;
+  pageInput: string;
+  setPageInput: (value: string) => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onGoToPage: () => void;
+}
+
+export function useRanking(
+  config: UseRankingConfig,
+  rankingPromise: Promise<RankingEntry[]>,
+): UseRankingResult {
+  const navigate = useNavigate();
+  const { count, offset } = useParams();
+  const [parsedCount, parsedOffset] = parseCountOffset(count, offset);
+  const cacheKey = config.buildFetchUrl(parsedCount, parsedOffset);
+
+  const ranking = use(rankingPromise);
+
+  const [pageInput, setPageInput] = useState(() =>
+    computePageInput(parsedCount, parsedOffset),
+  );
+
+  const prevCacheKeyRef = useRef(cacheKey);
+  if (prevCacheKeyRef.current !== cacheKey) {
+    prevCacheKeyRef.current = cacheKey;
+    setPageInput(computePageInput(parsedCount, parsedOffset));
+  }
+
+  const showNext = computeShowNext(ranking.length, parsedCount);
+
+  function onPrev() {
+    const { count: navCount, offset: navOffset } = computePrevPage(
+      parsedCount,
+      parsedOffset,
+    );
+    startTransition(() => {
+      navigate(config.buildNavPath(navCount, navOffset));
+    });
+  }
+
+  function onNext() {
+    const { count: navCount, offset: navOffset } = computeNextPage(
+      parsedCount,
+      parsedOffset,
+    );
+    startTransition(() => {
+      navigate(config.buildNavPath(navCount, navOffset));
+    });
+  }
+
+  function onGoToPage() {
+    const page = parseInt(pageInput, 10);
+    const result = computeGoToPage(parsedCount, page);
+    if (result) {
+      startTransition(() => {
+        navigate(config.buildNavPath(result.count, result.offset));
+      });
+    }
+  }
+
+  return {
+    ranking,
+    showNext,
+    pageInput,
+    setPageInput,
+    onPrev,
+    onNext,
+    onGoToPage,
+  };
+}

--- a/frontend/src/hooks/useRanking.ts
+++ b/frontend/src/hooks/useRanking.ts
@@ -55,9 +55,7 @@ export async function fetchRanking(
       })),
     })),
     lastUpdateMs:
-      parsed.last_update !== null
-        ? parseUtcTimestamp(parsed.last_update)
-        : null,
+      parsed.last_update != null ? parseUtcTimestamp(parsed.last_update) : null,
   };
 }
 

--- a/frontend/src/hooks/useRanking.ts
+++ b/frontend/src/hooks/useRanking.ts
@@ -2,8 +2,10 @@ import type React from "react";
 import { startTransition, use, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { NotFoundError } from "../errors/NotFoundError";
-import type { PlayerRankResponse } from "../interfaces/API";
+import type { PlayerRankResponse, RankResponse } from "../interfaces/API";
 import { JSONParse } from "../utils/JSONParse";
+import type { EpochMs } from "../utils/time";
+import { parseUtcTimestamp } from "../utils/time";
 
 export interface RankingTag {
   tag: string;
@@ -12,6 +14,11 @@ export interface RankingTag {
 
 export interface RankingEntry extends Omit<PlayerRankResponse, "tags"> {
   tags: RankingTag[];
+}
+
+export interface RankingFetchResult {
+  ranks: RankingEntry[];
+  lastUpdateMs: EpochMs | null;
 }
 
 export interface UseRankingConfig {
@@ -23,7 +30,7 @@ export async function fetchRanking(
   config: Pick<UseRankingConfig, "buildFetchUrl">,
   count: number,
   offset: number,
-): Promise<RankingEntry[]> {
+): Promise<RankingFetchResult> {
   const url = config.buildFetchUrl(count, offset);
   const response = await fetch(url);
 
@@ -37,19 +44,21 @@ export async function fetchRanking(
   }
 
   const body = await response.text();
-  const parsed = JSONParse(body) as {
-    ranks: (Omit<PlayerRankResponse, "tags"> & {
-      tags: { tag: string; style: string }[];
-    })[];
-  };
+  const parsed = JSONParse(body) as RankResponse;
 
-  return parsed.ranks.map((entry) => ({
-    ...entry,
-    tags: entry.tags.map((tag) => ({
-      tag: tag.tag,
-      style: JSON.parse(tag.style) as React.CSSProperties,
+  return {
+    ranks: parsed.ranks.map((entry) => ({
+      ...entry,
+      tags: entry.tags.map((tag) => ({
+        tag: tag.tag,
+        style: JSON.parse(tag.style) as React.CSSProperties,
+      })),
     })),
-  }));
+    lastUpdateMs:
+      parsed.last_update !== null
+        ? parseUtcTimestamp(parsed.last_update)
+        : null,
+  };
 }
 
 const DEFAULT_COUNT = 100;
@@ -65,14 +74,14 @@ function parseCountOffset(
 
 export function useRankingPromise(
   config: Pick<UseRankingConfig, "buildFetchUrl">,
-): Promise<RankingEntry[]> {
+): Promise<RankingFetchResult> {
   const { count, offset } = useParams();
   const [parsedCount, parsedOffset] = parseCountOffset(count, offset);
   const cacheKey = config.buildFetchUrl(parsedCount, parsedOffset);
 
   const cacheRef = useRef<{
     key: string;
-    promise: Promise<RankingEntry[]>;
+    promise: Promise<RankingFetchResult>;
   } | null>(null);
 
   if (!cacheRef.current || cacheRef.current.key !== cacheKey) {
@@ -129,6 +138,7 @@ export function computeGoToPage(
 
 export interface UseRankingResult {
   ranking: RankingEntry[];
+  lastUpdateMs: EpochMs | null;
   showNext: boolean;
   pageInput: string;
   setPageInput: (value: string) => void;
@@ -139,14 +149,13 @@ export interface UseRankingResult {
 
 export function useRanking(
   config: UseRankingConfig,
-  rankingPromise: Promise<RankingEntry[]>,
+  rankingPromise: Promise<RankingFetchResult>,
 ): UseRankingResult {
   const navigate = useNavigate();
   const { count, offset } = useParams();
   const [parsedCount, parsedOffset] = parseCountOffset(count, offset);
   const cacheKey = config.buildFetchUrl(parsedCount, parsedOffset);
-
-  const ranking = use(rankingPromise);
+  const { ranks: ranking, lastUpdateMs } = use(rankingPromise);
 
   const [pageInput, setPageInput] = useState(() =>
     computePageInput(parsedCount, parsedOffset),
@@ -192,6 +201,7 @@ export function useRanking(
 
   return {
     ranking,
+    lastUpdateMs,
     showNext,
     pageInput,
     setPageInput,

--- a/frontend/src/hooks/useSearchNavigation.test.ts
+++ b/frontend/src/hooks/useSearchNavigation.test.ts
@@ -37,12 +37,12 @@ describe("buildSearchPath", () => {
       input: "ソル",
       expected: "/search?q=%E3%82%BD%E3%83%AB",
     },
-  ])("encodes special characters in the search string: $label", ({
-    input,
-    expected,
-  }) => {
-    expect(buildSearchPath(input, false)).toBe(expected);
-  });
+  ])(
+    "encodes special characters in the search string: $label",
+    ({ input, expected }) => {
+      expect(buildSearchPath(input, false)).toBe(expected);
+    },
+  );
 
   test("regression: a literal 'exact' search string is not mistaken for the exact flag", () => {
     expect(buildSearchPath("exact", false)).toBe("/search?q=exact");

--- a/frontend/src/hooks/useTopGlobalRanking.ts
+++ b/frontend/src/hooks/useTopGlobalRanking.ts
@@ -1,4 +1,4 @@
-import type { RankingEntry, UseRankingResult } from "./useRanking";
+import type { RankingFetchResult, UseRankingResult } from "./useRanking";
 import { useRanking, useRankingPromise } from "./useRanking";
 
 const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
@@ -10,12 +10,12 @@ const config = {
     `/top_global/${count}/${offset}`,
 };
 
-export function useTopGlobalRankingPromise(): Promise<RankingEntry[]> {
+export function useTopGlobalRankingPromise(): Promise<RankingFetchResult> {
   return useRankingPromise(config);
 }
 
 export function useTopGlobalRanking(
-  rankingPromise: Promise<RankingEntry[]>,
+  rankingPromise: Promise<RankingFetchResult>,
 ): UseRankingResult {
   return useRanking(config, rankingPromise);
 }

--- a/frontend/src/hooks/useTopGlobalRanking.ts
+++ b/frontend/src/hooks/useTopGlobalRanking.ts
@@ -1,0 +1,21 @@
+import type { RankingEntry, UseRankingResult } from "./useRanking";
+import { useRanking, useRankingPromise } from "./useRanking";
+
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+
+const config = {
+  buildFetchUrl: (count: number, offset: number) =>
+    `${API_ENDPOINT}/top?count=${count}&offset=${offset}`,
+  buildNavPath: (count: number, offset: number) =>
+    `/top_global/${count}/${offset}`,
+};
+
+export function useTopGlobalRankingPromise(): Promise<RankingEntry[]> {
+  return useRankingPromise(config);
+}
+
+export function useTopGlobalRanking(
+  rankingPromise: Promise<RankingEntry[]>,
+): UseRankingResult {
+  return useRanking(config, rankingPromise);
+}

--- a/frontend/src/hooks/useTopPlayerRanking.ts
+++ b/frontend/src/hooks/useTopPlayerRanking.ts
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import type {
-  RankingEntry,
+  RankingFetchResult,
   UseRankingConfig,
   UseRankingResult,
 } from "./useRanking";
@@ -16,13 +16,13 @@ function buildConfig(char_short: string | undefined): UseRankingConfig {
   };
 }
 
-export function useTopPlayerRankingPromise(): Promise<RankingEntry[]> {
+export function useTopPlayerRankingPromise(): Promise<RankingFetchResult> {
   const { char_short } = useParams();
   return useRankingPromise(buildConfig(char_short));
 }
 
 export function useTopPlayerRanking(
-  rankingPromise: Promise<RankingEntry[]>,
+  rankingPromise: Promise<RankingFetchResult>,
 ): UseRankingResult {
   const { char_short } = useParams();
   return useRanking(buildConfig(char_short), rankingPromise);

--- a/frontend/src/hooks/useTopPlayerRanking.ts
+++ b/frontend/src/hooks/useTopPlayerRanking.ts
@@ -1,0 +1,29 @@
+import { useParams } from "react-router-dom";
+import type {
+  RankingEntry,
+  UseRankingConfig,
+  UseRankingResult,
+} from "./useRanking";
+import { useRanking, useRankingPromise } from "./useRanking";
+
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+
+function buildConfig(char_short: string | undefined): UseRankingConfig {
+  return {
+    buildFetchUrl: (count, offset) =>
+      `${API_ENDPOINT}/top_char/${char_short}?count=${count}&offset=${offset}`,
+    buildNavPath: (count, offset) => `/top/${char_short}/${count}/${offset}`,
+  };
+}
+
+export function useTopPlayerRankingPromise(): Promise<RankingEntry[]> {
+  const { char_short } = useParams();
+  return useRankingPromise(buildConfig(char_short));
+}
+
+export function useTopPlayerRanking(
+  rankingPromise: Promise<RankingEntry[]>,
+): UseRankingResult {
+  const { char_short } = useParams();
+  return useRanking(buildConfig(char_short), rankingPromise);
+}

--- a/frontend/src/interfaces/API.tsx
+++ b/frontend/src/interfaces/API.tsx
@@ -64,7 +64,7 @@ export interface PlayerSet {
 
 export interface RankResponse {
   ranks: PlayerRankResponse[]; // List of player rankings
-  last_update?: string; // UTC timestamp "YYYY-MM-DD HH:MM:SS"
+  last_update: string | null; // UTC timestamp "YYYY-MM-DD HH:MM:SS"
 }
 
 export interface PlayerRankResponse {

--- a/frontend/src/pages/TopGlobal.tsx
+++ b/frontend/src/pages/TopGlobal.tsx
@@ -15,20 +15,23 @@ import { Suspense } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { Tag } from "./../components/Tag";
-import type { RankingEntry } from "../hooks/useRanking";
+import { UpdateCountdown } from "../components/UpdateCountdown";
+import type { RankingFetchResult } from "../hooks/useRanking";
 import {
   useTopGlobalRanking,
   useTopGlobalRankingPromise,
 } from "../hooks/useTopGlobalRanking";
+import { ONE_DAY_MS } from "../utils/time";
 import { Utils } from "../utils/Utils";
 
 const TopGlobalTable = ({
   rankingPromise,
 }: {
-  rankingPromise: Promise<RankingEntry[]>;
+  rankingPromise: Promise<RankingFetchResult>;
 }) => {
   const {
     ranking,
+    lastUpdateMs,
     showNext,
     pageInput,
     setPageInput,
@@ -39,6 +42,9 @@ const TopGlobalTable = ({
 
   return (
     <Box sx={{ m: 3 }}>
+      {lastUpdateMs !== null && (
+        <UpdateCountdown lastUpdateMs={lastUpdateMs} intervalMs={ONE_DAY_MS} />
+      )}
       <Box sx={{ display: "inline-block", mb: 2 }}>
         <Button onClick={onPrev}>Prev</Button>
         <Button style={showNext ? {} : { display: "none" }} onClick={onNext}>

--- a/frontend/src/pages/TopGlobal.tsx
+++ b/frontend/src/pages/TopGlobal.tsx
@@ -11,178 +11,157 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import type React from "react";
-import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Suspense } from "react";
+import { Link, useParams } from "react-router-dom";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { Tag } from "./../components/Tag";
-import { JSONParse } from "../utils/JSONParse";
+import type { RankingEntry } from "../hooks/useRanking";
+import {
+  useTopGlobalRanking,
+  useTopGlobalRankingPromise,
+} from "../hooks/useTopGlobalRanking";
 import { Utils } from "../utils/Utils";
 
-const TopGlobal = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
-
-  const defaultCount = 100;
-
-  const navigate = useNavigate();
-
-  interface Player {
-    rank: number;
-    id: string;
-    name: string;
-    char_short: string;
-    rating: number;
-    tags?: { style: React.CSSProperties; tag: string }[];
-    is_legend: boolean;
-  }
-
-  const [ranking, setRanking] = useState<Player[]>([]);
-  const [nextUpdateIn, setNextUpdateIn] = useState<number | null>(null);
-
-  const formatCountdown = (s: number) => {
-    const h = Math.floor(s / 3600);
-    const m = Math.floor((s % 3600) / 60);
-    const sec = s % 60;
-    return `${h}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
-  };
-
-  useEffect(() => {
-    const id = setInterval(() => {
-      setNextUpdateIn((prev) => (prev !== null ? prev - 1 : null));
-    }, 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  const [showNext, setShowNext] = useState(true);
-
-  const { count, offset } = useParams();
-
-  const [loading, setLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [pageInput, setPageInput] = useState("");
-
-  useEffect(() => {
-    document.title = "Top Players | Puddle Farm";
-    window.scrollTo(0, 0);
-
-    const currentPage =
-      Math.floor(
-        (offset ? parseInt(offset, 10) : 0) /
-          (count ? parseInt(count, 10) : defaultCount),
-      ) + 1;
-    setPageInput(String(currentPage));
-
-    const fetchRanking = async () => {
-      setLoading(true);
-      setErrorMessage(null);
-      try {
-        const url =
-          API_ENDPOINT +
-          "/top?" +
-          "count=" +
-          (count ? count : defaultCount) +
-          "&offset=" +
-          (offset ? offset : 0);
-        const response = await fetch(url);
-
-        if (response.status === 404) {
-          navigate(`/`);
-          return;
-        }
-
-        if (!response.ok) {
-          const text = await response.text();
-          setErrorMessage(text || `Error ${response.status}`);
-          setLoading(false);
-          return;
-        }
-
-        const _result = await response.text().then((body) => {
-          const parsed = JSONParse(body);
-
-          for (const key in parsed.ranks) {
-            if (parsed.ranks[key].tags) {
-              for (const s in parsed.ranks[key].tags) {
-                parsed.ranks[key].tags[s].style = JSON.parse(
-                  parsed.ranks[key].tags[s].style,
-                );
-              }
-            }
-          }
-
-          if (
-            parsed.ranks.length < (count ? count : defaultCount) ||
-            parsed.ranks.length === 1000
-          ) {
-            setShowNext(false);
-          } else {
-            setShowNext(true);
-          }
-
-          setRanking(parsed.ranks);
-
-          if (parsed.last_update) {
-            const lastUpdate = new Date(`${parsed.last_update}Z`);
-            const secondsLeft = Math.floor(
-              (lastUpdate.getTime() + 86400_000 - Date.now()) / 1000,
-            );
-            setNextUpdateIn(secondsLeft);
-          }
-
-          return parsed;
-        });
-
-        setLoading(false);
-      } catch (error) {
-        console.error("Error fetching player data:", error);
-        setErrorMessage("Could not connect to the API.");
-        setLoading(false);
-      }
-    };
-
-    fetchRanking();
-  }, [count, offset, navigate]);
-
-  function onPrev(_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-    let nav_count = count ? parseInt(count, 10) : defaultCount;
-    let nav_offset = offset ? parseInt(offset, 10) - nav_count : 0;
-    if (nav_count < 0) {
-      nav_count = defaultCount;
-    }
-    if (nav_offset < 0) {
-      nav_offset = 0;
-    }
-    navigate(`/top_global/${nav_count}/${nav_offset}`);
-  }
-
-  function onNext(_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
-    const nav_count = count ? parseInt(count, 10) : defaultCount;
-    const nav_offset = offset ? parseInt(offset, 10) + nav_count : nav_count;
-    navigate(`/top_global/${nav_count}/${nav_offset}`);
-  }
-
-  function onGoToPage() {
-    const page = parseInt(pageInput, 10);
-    if (!Number.isNaN(page) && page > 0) {
-      const nav_count = count ? parseInt(count, 10) : defaultCount;
-      navigate(`/top_global/${nav_count}/${(page - 1) * nav_count}`);
-    }
-  }
+const TopGlobalTable = ({
+  rankingPromise,
+}: {
+  rankingPromise: Promise<RankingEntry[]>;
+}) => {
+  const {
+    ranking,
+    showNext,
+    pageInput,
+    setPageInput,
+    onPrev,
+    onNext,
+    onGoToPage,
+  } = useTopGlobalRanking(rankingPromise);
 
   return (
+    <Box sx={{ m: 3 }}>
+      <Box sx={{ display: "inline-block", mb: 2 }}>
+        <Button onClick={onPrev}>Prev</Button>
+        <Button style={showNext ? {} : { display: "none" }} onClick={onNext}>
+          Next
+        </Button>
+        <TextField
+          size="small"
+          label="Page"
+          type="number"
+          value={pageInput}
+          onChange={(e) => setPageInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
+          sx={{ width: 80, mx: 1 }}
+        />
+        <Button onClick={onGoToPage}>Go</Button>
+      </Box>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ px: 0, mx: 0 }}></TableCell>
+              <TableCell>Player</TableCell>
+              <TableCell>Char</TableCell>
+              <TableCell>Rating</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {ranking.map((player) => (
+              <TableRow key={`${player.id}-${player.char_short}`}>
+                <TableCell sx={{ px: 0, mx: 0, textAlign: "center" }}>
+                  {player.rank}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    component={Link}
+                    sx={{ justifyContent: "flex-start", minWidth: "auto" }}
+                    to={`/player/${player.id}/${player.char_short}`}
+                  >
+                    {player.name}
+                  </Button>
+                  {player.tags?.map((e) => (
+                    <Tag
+                      key={e.tag}
+                      style={e.style}
+                      sx={{ fontSize: "0.9rem", position: "unset" }}
+                    >
+                      {e.tag}
+                    </Tag>
+                  ))}
+                </TableCell>
+                <TableCell>{player.char_short}</TableCell>
+                <TableCell>
+                  <Box
+                    component={"span"}
+                    sx={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "8px",
+                    }}
+                  >
+                    {Utils.displayRankIcon(
+                      player.rating,
+                      "32px",
+                      player.is_legend,
+                    )}
+                    <Box component={"span"} title={String(player.rating)}>
+                      {Utils.displayRating(player.rating)}
+                    </Box>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Box sx={{ display: "inline-block", mt: 2 }}>
+        <Button onClick={onPrev}>Prev</Button>
+        <Button style={showNext ? {} : { display: "none" }} onClick={onNext}>
+          Next
+        </Button>
+        <TextField
+          size="small"
+          label="Page"
+          type="number"
+          value={pageInput}
+          onChange={(e) => setPageInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
+          sx={{ width: 80, mx: 1 }}
+        />
+        <Button onClick={onGoToPage}>Go</Button>
+      </Box>
+    </Box>
+  );
+};
+
+const TopGlobalContent = () => {
+  const { count, offset } = useParams();
+  const rankingPromise = useTopGlobalRankingPromise();
+
+  return (
+    <ErrorBoundary resetKey={`${count}-${offset}`}>
+      <Suspense
+        fallback={
+          <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+            <CircularProgress size={60} variant="indeterminate" />
+          </Box>
+        }
+      >
+        <TopGlobalTable rankingPromise={rankingPromise} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+const TopGlobal = () => {
+  return (
     <>
+      <title>Top Players | Puddle Farm</title>
       <AppBar
         position="static"
         style={{ backgroundImage: "none" }}
         sx={{ backgroundColor: "secondary.main" }}
       >
-        {loading ? (
-          <CircularProgress
-            size={60}
-            variant="indeterminate"
-            disableShrink={true}
-            sx={{ position: "absolute", top: "-1px", color: "white" }}
-          />
-        ) : null}
         <Box
           sx={{
             minHeight: 100,
@@ -196,117 +175,7 @@ const TopGlobal = () => {
           </Typography>
         </Box>
       </AppBar>
-      <Box sx={{ m: 3 }}>
-        {errorMessage && (
-          <Typography color="error" align="center" sx={{ mb: 2 }}>
-            {errorMessage}
-          </Typography>
-        )}
-        {nextUpdateIn !== null && (
-          <Typography align="left" sx={{ mb: 1 }}>
-            {nextUpdateIn > 0
-              ? `Next update in: ${formatCountdown(nextUpdateIn)}`
-              : "Updating..."}
-          </Typography>
-        )}
-        <Box sx={{ display: "inline-block", mb: 2 }}>
-          <Button onClick={(event) => onPrev(event)}>Prev</Button>
-          <Button
-            style={showNext ? {} : { display: "none" }}
-            onClick={(event) => onNext(event)}
-          >
-            Next
-          </Button>
-          <TextField
-            size="small"
-            label="Page"
-            type="number"
-            value={pageInput}
-            onChange={(e) => setPageInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
-            sx={{ width: 80, mx: 1 }}
-          />
-          <Button onClick={onGoToPage}>Go</Button>
-        </Box>
-        <TableContainer component={Paper}>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ px: 0, mx: 0 }}></TableCell>
-                <TableCell>Player</TableCell>
-                <TableCell>Char</TableCell>
-                <TableCell>Rating</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {ranking.map((player) => (
-                <TableRow key={`${player.id}-${player.char_short}`}>
-                  <TableCell sx={{ px: 0, mx: 0, textAlign: "center" }}>
-                    {player.rank}
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      component={Link}
-                      sx={{ justifyContent: "flex-start", minWidth: "auto" }}
-                      to={`/player/${player.id}/${player.char_short}`}
-                    >
-                      {player.name}
-                    </Button>
-                    {player.tags?.map((e) => (
-                      <Tag
-                        key={e.tag}
-                        style={e.style}
-                        sx={{ fontSize: "0.9rem", position: "unset" }}
-                      >
-                        {e.tag}
-                      </Tag>
-                    ))}
-                  </TableCell>
-                  <TableCell>{player.char_short}</TableCell>
-                  <TableCell>
-                    <Box
-                      component={"span"}
-                      sx={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: "8px",
-                      }}
-                    >
-                      {Utils.displayRankIcon(
-                        player.rating,
-                        "32px",
-                        player.is_legend,
-                      )}
-                      <Box component={"span"} title={String(player.rating)}>
-                        {Utils.displayRating(player.rating)}
-                      </Box>
-                    </Box>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-        <Box sx={{ display: "inline-block", mt: 2 }}>
-          <Button onClick={(event) => onPrev(event)}>Prev</Button>
-          <Button
-            style={showNext ? {} : { display: "none" }}
-            onClick={(event) => onNext(event)}
-          >
-            Next
-          </Button>
-          <TextField
-            size="small"
-            label="Page"
-            type="number"
-            value={pageInput}
-            onChange={(e) => setPageInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
-            sx={{ width: 80, mx: 1 }}
-          />
-          <Button onClick={onGoToPage}>Go</Button>
-        </Box>
-      </Box>
+      <TopGlobalContent />
     </>
   );
 };

--- a/frontend/src/pages/TopPlayer.tsx
+++ b/frontend/src/pages/TopPlayer.tsx
@@ -11,216 +11,53 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Suspense } from "react";
+import { Link, useParams } from "react-router-dom";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { Tag } from "./../components/Tag";
-import type { PlayerRankResponse } from "../interfaces/API";
-import { JSONParse } from "../utils/JSONParse";
+import { useCharacterNames } from "../hooks/useCharacterNames";
+import type { RankingEntry } from "../hooks/useRanking";
+import {
+  useTopPlayerRanking,
+  useTopPlayerRankingPromise,
+} from "../hooks/useTopPlayerRanking";
 import { Utils } from "../utils/Utils";
 
-const TopPlayer = () => {
-  const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
-
-  const defaultCount = 100;
-
-  const navigate = useNavigate();
-
-  const [ranking, setRanking] = useState<PlayerRankResponse[]>([]);
-  const [nextUpdateIn, setNextUpdateIn] = useState<number | null>(null);
-
-  const formatCountdown = (s: number) => {
-    const h = Math.floor(s / 3600);
-    const m = Math.floor((s % 3600) / 60);
-    const sec = s % 60;
-    return `${h}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
-  };
-
-  useEffect(() => {
-    const id = setInterval(() => {
-      setNextUpdateIn((prev) => (prev !== null ? prev - 1 : null));
-    }, 1000);
-    return () => clearInterval(id);
-  }, []);
-
-  const [showNext, setShowNext] = useState<boolean>(true);
-
-  const { char_short, count, offset } = useParams();
-
-  const [charLong, setCharLong] = useState<string>();
-
-  const [loading, setLoading] = useState<boolean>(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [pageInput, setPageInput] = useState("");
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-
-    const currentPage =
-      Math.floor(
-        (offset ? parseInt(offset, 10) : 0) /
-          (count ? parseInt(count, 10) : defaultCount),
-      ) + 1;
-    setPageInput(String(currentPage));
-
-    const fetchRanking = async () => {
-      setLoading(true);
-      setErrorMessage(null);
-      try {
-        const url =
-          API_ENDPOINT +
-          "/top_char/" +
-          char_short +
-          "?count=" +
-          (count ? count : defaultCount) +
-          "&offset=" +
-          (offset ? offset : 0);
-        const response = await fetch(url);
-
-        if (response.status === 404) {
-          navigate(`/`);
-          return;
-        }
-
-        if (!response.ok) {
-          const text = await response.text();
-          setErrorMessage(text || `Error ${response.status}`);
-          setLoading(false);
-          return;
-        }
-
-        const _result = await response.text().then((body) => {
-          const parsed = JSONParse(body);
-
-          if (parsed.ranks.length === 0) {
-            //navigate(`/`);
-            setCharLong("???");
-            setRanking([]);
-            return;
-          }
-
-          setCharLong(parsed.ranks[0].char_long);
-
-          document.title = `Top ${parsed.ranks[0].char_long} Players | Puddle Farm`;
-
-          if (
-            parsed.ranks.length < (count ? count : defaultCount) ||
-            parsed.ranks.length === 1000
-          ) {
-            setShowNext(false);
-          } else {
-            setShowNext(true);
-          }
-
-          setRanking(parsed.ranks);
-
-          if (parsed.last_update) {
-            const lastUpdate = new Date(`${parsed.last_update}Z`);
-            const secondsLeft = Math.floor(
-              (lastUpdate.getTime() + 86400_000 - Date.now()) / 1000,
-            );
-            setNextUpdateIn(secondsLeft);
-          }
-
-          return parsed;
-        });
-
-        setLoading(false);
-      } catch (error) {
-        console.error("Error fetching player data:", error);
-        setErrorMessage("Could not connect to the API.");
-        setLoading(false);
-      }
-    };
-
-    fetchRanking();
-  }, [char_short, count, offset, navigate]);
-
-  function onPrev() {
-    let nav_count = count ? parseInt(count, 10) : defaultCount;
-    let nav_offset = offset ? parseInt(offset, 10) - nav_count : 0;
-    if (nav_count < 0) {
-      nav_count = defaultCount;
-    }
-    if (nav_offset < 0) {
-      nav_offset = 0;
-    }
-    navigate(`/top/${char_short}/${nav_count}/${nav_offset}`);
-  }
-
-  function onNext() {
-    const nav_count = count ? parseInt(count, 10) : defaultCount;
-    const nav_offset = offset ? parseInt(offset, 10) + nav_count : nav_count;
-    navigate(`/top/${char_short}/${nav_count}/${nav_offset}`);
-  }
-
-  function onGoToPage() {
-    const page = parseInt(pageInput, 10);
-    if (!Number.isNaN(page) && page > 0) {
-      const nav_count = count ? parseInt(count, 10) : defaultCount;
-      navigate(`/top/${char_short}/${nav_count}/${(page - 1) * nav_count}`);
-    }
-  }
+const TopPlayerTable = ({
+  rankingPromise,
+}: {
+  rankingPromise: Promise<RankingEntry[]>;
+}) => {
+  const {
+    ranking,
+    showNext,
+    pageInput,
+    setPageInput,
+    onPrev,
+    onNext,
+    onGoToPage,
+  } = useTopPlayerRanking(rankingPromise);
 
   return (
-    <>
-      <AppBar
-        position="static"
-        style={{ backgroundImage: "none" }}
-        sx={{ backgroundColor: "secondary.main" }}
-      >
-        {loading ? (
-          <CircularProgress
-            size={60}
-            variant="indeterminate"
-            disableShrink={true}
-            sx={{ position: "absolute", top: "-1px", color: "white" }}
-          />
-        ) : null}
-        <Box
-          sx={{
-            minHeight: 100,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <Typography align="center" variant="pageHeader">
-            {charLong} Leaderboard
-          </Typography>
-        </Box>
-      </AppBar>
-      <Box sx={{ m: 4 }}>
-        {errorMessage && (
-          <Typography color="error" align="center" sx={{ mb: 2 }}>
-            {errorMessage}
-          </Typography>
-        )}
-        {nextUpdateIn !== null && (
-          <Typography align="left" sx={{ mb: 1 }}>
-            {nextUpdateIn > 0
-              ? `Next update in: ${formatCountdown(nextUpdateIn)}`
-              : "Updating..."}
-          </Typography>
-        )}
-        <Box sx={{ mx: 3, display: "inline-block", mb: 2 }}>
-          <Button onClick={() => onPrev()}>Prev</Button>
-          <Button
-            style={showNext ? {} : { display: "none" }}
-            onClick={() => onNext()}
-          >
-            Next
-          </Button>
-          <TextField
-            size="small"
-            label="Page"
-            type="number"
-            value={pageInput}
-            onChange={(e) => setPageInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
-            sx={{ width: 80, mx: 1 }}
-          />
-          <Button onClick={onGoToPage}>Go</Button>
-        </Box>
+    <Box sx={{ m: 4 }}>
+      <Box sx={{ mx: 3, display: "inline-block", mb: 2 }}>
+        <Button onClick={onPrev}>Prev</Button>
+        <Button style={showNext ? {} : { display: "none" }} onClick={onNext}>
+          Next
+        </Button>
+        <TextField
+          size="small"
+          label="Page"
+          type="number"
+          value={pageInput}
+          onChange={(e) => setPageInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
+          sx={{ width: 80, mx: 1 }}
+        />
+        <Button onClick={onGoToPage}>Go</Button>
+      </Box>
+
+      {ranking.length > 0 && (
         <TableContainer component={Paper}>
           <Table size="small">
             <TableHead>
@@ -248,7 +85,7 @@ const TopPlayer = () => {
                     {player.tags?.map((e) => (
                       <Tag
                         key={e.tag}
-                        style={JSON.parse(e.style)}
+                        style={e.style}
                         sx={{ fontSize: "0.9rem", position: "unset" }}
                       >
                         {e.tag}
@@ -280,26 +117,75 @@ const TopPlayer = () => {
             </TableBody>
           </Table>
         </TableContainer>
-        <Box sx={{ mx: 3, display: "inline-block", mt: 2 }}>
-          <Button onClick={() => onPrev()}>Prev</Button>
-          <Button
-            style={showNext ? {} : { display: "none" }}
-            onClick={() => onNext()}
-          >
-            Next
-          </Button>
-          <TextField
-            size="small"
-            label="Page"
-            type="number"
-            value={pageInput}
-            onChange={(e) => setPageInput(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
-            sx={{ width: 80, mx: 1 }}
-          />
-          <Button onClick={onGoToPage}>Go</Button>
-        </Box>
+      )}
+      <Box sx={{ mx: 3, display: "inline-block", mt: 2 }}>
+        <Button onClick={onPrev}>Prev</Button>
+        <Button style={showNext ? {} : { display: "none" }} onClick={onNext}>
+          Next
+        </Button>
+        <TextField
+          size="small"
+          label="Page"
+          type="number"
+          value={pageInput}
+          onChange={(e) => setPageInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && onGoToPage()}
+          sx={{ width: 80, mx: 1 }}
+        />
+        <Button onClick={onGoToPage}>Go</Button>
       </Box>
+    </Box>
+  );
+};
+
+const TopPlayerContent = () => {
+  const { char_short, count, offset } = useParams();
+  const rankingPromise = useTopPlayerRankingPromise();
+
+  return (
+    <ErrorBoundary resetKey={`${char_short}-${count}-${offset}`}>
+      <Suspense
+        fallback={
+          <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+            <CircularProgress size={60} variant="indeterminate" />
+          </Box>
+        }
+      >
+        <TopPlayerTable rankingPromise={rankingPromise} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+const TopPlayer = () => {
+  const { char_short } = useParams();
+  const characterNames = useCharacterNames();
+  const characterFullName = char_short
+    ? characterNames?.[char_short]
+    : undefined;
+
+  return (
+    <>
+      <title>{`Top ${characterFullName ?? ""} Players | Puddle Farm`}</title>
+      <AppBar
+        position="static"
+        style={{ backgroundImage: "none" }}
+        sx={{ backgroundColor: "secondary.main" }}
+      >
+        <Box
+          sx={{
+            minHeight: 100,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Typography align="center" variant="pageHeader">
+            {`${characterFullName ?? ""} Leaderboard`}
+          </Typography>
+        </Box>
+      </AppBar>
+      <TopPlayerContent />
     </>
   );
 };

--- a/frontend/src/pages/TopPlayer.tsx
+++ b/frontend/src/pages/TopPlayer.tsx
@@ -15,21 +15,24 @@ import { Suspense } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { Tag } from "./../components/Tag";
+import { UpdateCountdown } from "../components/UpdateCountdown";
 import { useCharacterNames } from "../hooks/useCharacterNames";
-import type { RankingEntry } from "../hooks/useRanking";
+import type { RankingFetchResult } from "../hooks/useRanking";
 import {
   useTopPlayerRanking,
   useTopPlayerRankingPromise,
 } from "../hooks/useTopPlayerRanking";
+import { ONE_DAY_MS } from "../utils/time";
 import { Utils } from "../utils/Utils";
 
 const TopPlayerTable = ({
   rankingPromise,
 }: {
-  rankingPromise: Promise<RankingEntry[]>;
+  rankingPromise: Promise<RankingFetchResult>;
 }) => {
   const {
     ranking,
+    lastUpdateMs,
     showNext,
     pageInput,
     setPageInput,
@@ -40,6 +43,9 @@ const TopPlayerTable = ({
 
   return (
     <Box sx={{ m: 4 }}>
+      {lastUpdateMs !== null && (
+        <UpdateCountdown lastUpdateMs={lastUpdateMs} intervalMs={ONE_DAY_MS} />
+      )}
       <Box sx={{ mx: 3, display: "inline-block", mb: 2 }}>
         <Button onClick={onPrev}>Prev</Button>
         <Button style={showNext ? {} : { display: "none" }} onClick={onNext}>

--- a/frontend/src/utils/Utils.jsx
+++ b/frontend/src/utils/Utils.jsx
@@ -205,6 +205,12 @@ const Utils = {
     }
     return dateTimeString;
   },
+  formatCountdown: (s) => {
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    return `${h}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+  },
   colorChangeForRating: (change) => {
     if (StorageUtils.getDisableRatingColors()) {
       return <>{change}</>;

--- a/frontend/src/utils/Utils.test.ts
+++ b/frontend/src/utils/Utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { Utils } from "./Utils";
+
+describe("formatCountdown", () => {
+  test("formats seconds as H:MM:SS", () => {
+    expect(Utils.formatCountdown(3661)).toBe("1:01:01");
+  });
+
+  test("pads minutes and seconds under 10", () => {
+    expect(Utils.formatCountdown(65)).toBe("0:01:05");
+  });
+
+  test("formats zero as 0:00:00", () => {
+    expect(Utils.formatCountdown(0)).toBe("0:00:00");
+  });
+});

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -8,10 +8,8 @@ describe("parseUtcTimestamp", () => {
     expect(ms).toBe(Date.parse("2026-01-01T00:00:00.000Z"));
   });
 
-  test("throws on an invalid timestamp string", () => {
-    expect(() => parseUtcTimestamp("not-a-date")).toThrow(
-      'invalid UTC timestamp "not-a-date"',
-    );
+  test("returns null for an invalid timestamp string", () => {
+    expect(parseUtcTimestamp("not-a-date")).toBeNull();
   });
 });
 

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import type { DurationMs, EpochMs } from "./time";
+import { addDuration, parseUtcTimestamp } from "./time";
+
+describe("parseUtcTimestamp", () => {
+  test("parses a UTC timestamp string as epoch milliseconds", () => {
+    const ms = parseUtcTimestamp("2026-01-01 00:00:00");
+    expect(ms).toBe(Date.parse("2026-01-01T00:00:00.000Z"));
+  });
+
+  test("throws on an invalid timestamp string", () => {
+    expect(() => parseUtcTimestamp("not-a-date")).toThrow(
+      'invalid UTC timestamp "not-a-date"',
+    );
+  });
+});
+
+describe("addDuration", () => {
+  test("adds a duration to an epoch timestamp", () => {
+    const epoch = 1_000 as EpochMs;
+    const duration = 500 as DurationMs;
+    expect(addDuration(epoch, duration)).toBe(1_500);
+  });
+});

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,16 @@
+export type EpochMs = number & { readonly __brand: "EpochMs" };
+export type DurationMs = number & { readonly __brand: "DurationMs" };
+
+export const ONE_DAY_MS = 86400_000 as DurationMs;
+
+export function addDuration(epoch: EpochMs, duration: DurationMs): EpochMs {
+  return (epoch + duration) as EpochMs;
+}
+
+export function parseUtcTimestamp(dateTimeString: string): EpochMs {
+  const ms = new Date(`${dateTimeString}Z`).getTime();
+  if (Number.isNaN(ms)) {
+    throw new Error(`invalid UTC timestamp "${dateTimeString}"`);
+  }
+  return ms as EpochMs;
+}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -7,10 +7,7 @@ export function addDuration(epoch: EpochMs, duration: DurationMs): EpochMs {
   return (epoch + duration) as EpochMs;
 }
 
-export function parseUtcTimestamp(dateTimeString: string): EpochMs {
+export function parseUtcTimestamp(dateTimeString: string): EpochMs | null {
   const ms = new Date(`${dateTimeString}Z`).getTime();
-  if (Number.isNaN(ms)) {
-    throw new Error(`invalid UTC timestamp "${dateTimeString}"`);
-  }
-  return ms as EpochMs;
+  return Number.isNaN(ms) ? null : (ms as EpochMs);
 }


### PR DESCRIPTION
## Summary
- Continue the UI/logic separation work from prior refactors: extract `useRanking`/`useTopGlobalRanking`/`useTopPlayerRanking` hooks for TopGlobal/TopPlayer's pagination and fetch logic
- Switch data fetching from `useState(loading)+useEffect` to Suspense + `use()`, matching the declarative pattern already used by Popularity/Search/Matchup, and removing manual loading-state branching from the render path
- Add `useCharacterNames`, shared between NavBar and TopPlayer, as a single source for char_short -> char_long resolution — this lets the page header/title be built from the URL alone, independent of the ranking fetch result
- Add a shared `ErrorBoundary` + `NotFoundError` for consistent 404/error handling under Suspense
- TopGlobal/TopPlayer intentionally keep separate page components rather than being merged, even though their DOM structure is currently similar minus the logic differences — this preserves per-page customization flexibility. Ranking/pagination concerns are already factored out via the hooks, so keeping the pages separate costs little in duplication going forward.

## Test plan
- [x] `npm run typecheck` / `npm run check` / `npm run test` all pass
- [x] TopGlobal/TopPlayer load and paginate correctly (Prev/Next/Go)
- [x] Switching characters on TopPlayer updates the header/title and ranking table
- [x] Visiting a nonexistent character/page redirects to `/`
- [x] Simulating a server error shows an error message