### PR TITLE
Add optional Docker dev environment + dummy data seed scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ diesel --database-url "${DATABASE_URL}" migration run
 
 `cargo run pull` will run the timed jobs continuously: grab replay, update ratings, update ranking, update redis, etc.
 
+#### Development database (Docker, optional)
+
+Requires [Docker](https://www.docker.com/) with Compose. If you don't want to
+install Postgres/Redis locally, `docker/docker-compose.dev.yml` provides both,
+plus a disposable `diesel_cli` container for running migrations (useful on
+Windows, where linking `diesel_cli` against `libpq` can be a hassle):
+
+```
+docker compose -p puddle-farm-dev -f docker/docker-compose.dev.yml up -d postgres redis
+docker compose -p puddle-farm-dev -f docker/docker-compose.dev.yml run --rm diesel migration run
+```
+
+Or use `scripts/seed/reset.sh` to do both from scratch (drops any existing
+data/volumes first).
+
+To populate the database with dummy data (players, ratings, matches, rankings)
+so the frontend has something to render without running `cargo run pull`, see
+`scripts/seed/README.md`.
+
 `cargo run hourly` runs the hourly jobs once, then exits.
 
 To generate a new model.rs:

--- a/docker/diesel/Dockerfile
+++ b/docker/diesel/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo install diesel_cli --no-default-features --features postgres
+
+ENTRYPOINT ["diesel"]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,34 @@
+services:
+  postgres:
+    image: postgres:18
+    container_name: pf-postgres
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: puddle_farm
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql
+
+  redis:
+    image: redis:latest
+    container_name: pf-redis
+    ports:
+      - "6379:6379"
+
+  # docker compose -f docker/docker-compose.dev.yml run --rm diesel migration run
+  diesel:
+    build: ./diesel
+    container_name: pf-diesel
+    profiles: ["tools"]
+    environment:
+      DATABASE_URL: postgresql://user:password@postgres/puddle_farm
+    volumes:
+      - ../migrations:/app/migrations
+    working_dir: /app
+    depends_on:
+      - postgres
+
+volumes:
+  pgdata:

--- a/scripts/seed/README.md
+++ b/scripts/seed/README.md
@@ -1,0 +1,55 @@
+# Dev database seed scripts
+
+Generate dummy data for a local backend so every page (Top, Legend, per-character rankings, search, Popularity, Matchup Tables, Rank Distribution) has something to show without running the real `cargo run pull` job (which requires a logged-in Steam client).
+
+## Prerequisites
+
+Requires Docker with Compose, and `bash`/`docker`/`docker compose` on `PATH`.
+
+Start the dev database first (see `docker/docker-compose.dev.yml`):
+
+```bash
+docker compose -p puddle-farm-dev -f docker/docker-compose.dev.yml up -d postgres redis
+docker compose -p puddle-farm-dev -f docker/docker-compose.dev.yml run --rm diesel migration run
+```
+
+Or just run `scripts/seed/reset.sh`, which does both from scratch (and drops any existing data/volumes).
+
+## What gets created
+
+With the defaults (`seed-all.sh` with no args):
+
+- **200 players** (`TestPlayer1`..`TestPlayer200`), one character rating each, spread across all 19 rank tiers (Placement..Diamond 3, ~10+ players per tier).
+- **Top 20** by rating are also written to `leaderboard_legend` (Legend page).
+- **`TestPlayer1`..`TestPlayer8`** additionally get a second character rating, for testing the character switcher on player pages.
+- **2000 regular ranked games** + **200 Vanquisher-tier games** (`value_a`/`value_b >= 10001600`), randomly paired between seeded players. Each match's rating value is offset from the player's base rating (winner up, loser down) so the frontend's per-match rating-change display isn't always 0.
+- Matchup Tables, Popularity, and Rank Distribution pages are all populated by aggregating the above (mirrors the real aggregation SQL in `src/pull.rs`).
+
+## Usage
+
+Run everything in the correct order:
+
+```bash
+bash scripts/seed/seed-all.sh [player_count]   # default 200
+```
+
+Or run scripts individually - **order matters**, each one depends on data from the previous step:
+
+1. `seed-players.sh [count]` - creates `players` / `player_ratings` spread across all 19 rank tiers (Placement through Diamond 3, at least ~10 players per tier), plus the `leaderboard_*` Redis keys (Top / per-character / Legend pages).
+2. `seed-games.sh [game_count] [vanq_game_count]` - creates dummy match history in `games`, required by the matchup/popularity scripts below.
+3. `seed-matchups.sh` - aggregates `games` into `matchup_*` / `matchup_vanq_*` Redis keys, mirroring the SQL in `src/pull.rs::update_matchups()`.
+4. `seed-distribution.sh` - aggregates `player_ratings` into the `distribution_rating` Redis key, mirroring `src/pull.rs::update_distribution()`.
+5. `seed-popularity.sh` - aggregates `games` into `popularity_per_player_*` / `popularity_per_character_*` Redis keys, mirroring `src/pull.rs::update_popularity()`.
+
+All scripts are re-runnable: seeded rows/games are deleted and re-inserted each time, so you can just re-run `seed-all.sh` to reshuffle the data.
+
+Re-running a single script in isolation is only safe for iterating on that script itself. `seed-players.sh` deletes and recreates `games` as part of resetting `player_ratings`, so running it alone leaves `games` empty while the `matchup_*`/`popularity_*` Redis keys still hold stale data from the previous `games` - re-run `seed-all.sh` afterward to restore consistency.
+
+## Reset
+
+`reset.sh` recreates the postgres/redis containers (and volumes) from scratch and re-runs migrations. The backend process holds stale DB/Redis connections after this - restart it afterward, then re-run `seed-all.sh` if you want data again.
+
+## Notes
+
+- Seeded player IDs start at `900000000000001`, well outside the real Steam64 ID range, so seeded data never collides with real players.
+- `seed-games.sh` also inserts a smaller batch of games with `value_a`/`value_b >= 10001600` (the Vanquisher floor) so `matchup_vanq_*` has data too, not just the regular `matchup_*` keys.

--- a/scripts/seed/reset.sh
+++ b/scripts/seed/reset.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Full reset: recreate postgres/redis containers (and volumes) from scratch, re-run migrations.
+# `down -v` is destructive - it drops the pgdata volume unconditionally, no confirmation.
+# The backend process holds stale DB/Redis connections after this runs - restart it afterward.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE="docker compose -p puddle-farm-dev -f $REPO_ROOT/docker/docker-compose.dev.yml"
+
+$COMPOSE down -v
+$COMPOSE up -d postgres redis
+
+echo "Waiting for Postgres to accept connections..."
+for i in $(seq 1 30); do
+  $COMPOSE exec -T postgres pg_isready -U user > /dev/null 2>&1 && break
+  if [ "$i" -eq 30 ]; then
+    echo "Postgres did not become ready after 30s." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+$COMPOSE run --rm diesel migration run
+
+echo "Reset complete. Restart the backend process (stale DB/Redis connections)."

--- a/scripts/seed/seed-all.sh
+++ b/scripts/seed/seed-all.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Runs every seed script in dependency order:
+#   seed-players.sh (players/ratings/leaderboard)
+#     -> seed-distribution.sh (rank distribution, needs only ratings)
+#     -> seed-games.sh (dummy match history)
+#         -> seed-matchups.sh (matchup tables, needs games)
+#         -> seed-popularity.sh (popularity, needs games)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+N="${1:-200}"
+GAME_COUNT="${2:-2000}"
+VANQ_GAME_COUNT="${3:-200}"
+
+bash "$SCRIPT_DIR/seed-players.sh" "$N"
+bash "$SCRIPT_DIR/seed-distribution.sh"
+bash "$SCRIPT_DIR/seed-games.sh" "$GAME_COUNT" "$VANQ_GAME_COUNT"
+bash "$SCRIPT_DIR/seed-matchups.sh"
+bash "$SCRIPT_DIR/seed-popularity.sh"

--- a/scripts/seed/seed-distribution.sh
+++ b/scripts/seed/seed-distribution.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Requires seed-players.sh to have been run first (reads from player_ratings).
+# Bucket/percentage/percentile SQL mirrors src/pull.rs update_distribution().
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PSQL="docker exec -i pf-postgres psql -v ON_ERROR_STOP=1 -U user -d puddle_farm"
+
+ID_BASE=900000000000000
+
+DIST_JSON=$($PSQL -tAc "
+-- Bucket boundaries copied from src/pull.rs update_distribution() - keep both in
+-- sync if rank tiers ever change (also duplicated a third time in seed-players.sh's
+-- ranks CTE, in a different format).
+WITH buckets AS (
+    SELECT
+      unnest(ARRAY[-10000000, 1,    1000, 2000, 3000, 4200, 5400, 6600, 8800,  11000, 13200, 15600, 18000, 20400, 24400, 28400, 32400, 36600, 40800, 10000000, 10001600, 10001700, 10001800]) AS lower_bound,
+      unnest(ARRAY[1, 1000, 2000, 3000, 4200, 5400, 6600, 8800, 11000, 13200, 15600, 18000, 20400, 24400, 28400, 32400, 36600, 40800, 10000000, 10001600, 10001700, 10001800, 200000000]) AS upper_bound
+),
+bucket_counts AS (
+    SELECT
+        b.lower_bound,
+        b.upper_bound,
+        count(t.value) AS bucket_count
+    FROM player_ratings t
+    LEFT JOIN buckets b ON t.value >= b.lower_bound AND t.value < b.upper_bound
+    WHERE t.id >= $ID_BASE  -- deviation from pull.rs: scope to seeded rows only
+    GROUP BY b.lower_bound, b.upper_bound
+),
+percentiles AS (
+    SELECT
+        lower_bound,
+        upper_bound,
+        bucket_count,
+        SUM(bucket_count) OVER (ORDER BY lower_bound) as cumulative_sum,
+        SUM(bucket_count) OVER () as total_count,
+        SUM(CASE WHEN upper_bound != 1 THEN bucket_count ELSE 0 END) OVER (ORDER BY lower_bound) as cumulative_sum_ranked_only,
+        SUM(bucket_count) FILTER (WHERE upper_bound != 1) OVER () as total_count_excluding_placement
+    FROM bucket_counts
+),
+final AS (
+    SELECT
+        p.lower_bound,
+        p.upper_bound,
+        p.bucket_count AS count,
+        CASE
+            WHEN p.upper_bound = 1 THEN CAST(ROUND((p.bucket_count * 100.0 / p.total_count), 2) AS FLOAT)
+            ELSE CAST(ROUND((p.bucket_count * 100.0 / p.total_count_excluding_placement), 2) AS FLOAT)
+        END AS percentage,
+        CASE
+            WHEN p.upper_bound = 1 THEN 0.0
+            ELSE CAST(ROUND((100.0 - ((p.cumulative_sum_ranked_only - p.bucket_count) * 100.0 / p.total_count_excluding_placement)), 2) AS FLOAT)
+        END AS percentile
+    FROM percentiles p
+    ORDER BY p.lower_bound
+)
+SELECT COALESCE(json_agg(row_to_json(final)), '[]') FROM final;
+")
+
+echo "$DIST_JSON" | docker exec -i pf-redis redis-cli -x SET distribution_rating > /dev/null
+
+ONE_MONTH_PLAYERS=$($PSQL -tAc "SELECT count(DISTINCT id) FROM player_ratings WHERE id >= $ID_BASE;" | tr -d '\r')
+docker exec pf-redis redis-cli SET one_month_players "$ONE_MONTH_PLAYERS" > /dev/null
+docker exec pf-redis redis-cli SET last_update_daily "$(date -u +"%Y-%m-%d %H:%M:%S")" > /dev/null
+
+echo "Seeded distribution_rating (one_month_players=$ONE_MONTH_PLAYERS)."

--- a/scripts/seed/seed-games.sh
+++ b/scripts/seed/seed-games.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Requires seed-players.sh to have been run first (reads from player_ratings).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PSQL="docker exec -i pf-postgres psql -v ON_ERROR_STOP=1 -U user -d puddle_farm"
+
+ID_BASE=900000000000000
+GAME_COUNT="${1:-2000}"
+VANQ_GAME_COUNT="${2:-200}"
+VANQ_VALUE_FLOOR=10001600
+
+PLAYER_COUNT=$($PSQL -tAc "SELECT count(*) FROM player_ratings WHERE id >= $ID_BASE;" | tr -d '\r')
+if [ "$PLAYER_COUNT" -eq 0 ]; then
+  echo "No seeded player_ratings found (id >= $ID_BASE). Run seed-players.sh first." >&2
+  exit 1
+fi
+
+$PSQL -v id_base="$ID_BASE" -v game_count="$GAME_COUNT" -v vanq_game_count="$VANQ_GAME_COUNT" -v vanq_floor="$VANQ_VALUE_FLOOR" <<'SQL'
+BEGIN;
+
+DELETE FROM games WHERE id_a >= :id_base OR id_b >= :id_base;
+
+-- Regular ranked matches. value_a/value_b get a small per-match offset around
+-- the player's base rating (winner +, loser -) instead of the raw base value,
+-- otherwise every match for a player has the same own_rating_value and the
+-- frontend's per-match rating-change display (own_rating_value delta between
+-- consecutive matches, see frontend/src/utils/Player.tsx groupMatches) is
+-- always 0.
+WITH pool AS (
+  SELECT pr.id, pr.char_id, pr.value, p.name
+  FROM player_ratings pr JOIN players p ON p.id = pr.id
+  WHERE pr.id >= :id_base
+),
+pairs AS (
+  SELECT
+    a.id AS id_a, a.name AS name_a, a.char_id AS char_a, a.value AS value_a,
+    b.id AS id_b, b.name AS name_b, b.char_id AS char_b, b.value AS value_b,
+    (CASE WHEN random() < 0.5 THEN 1 ELSE 2 END) AS winner
+  FROM pool a JOIN pool b ON a.id <> b.id
+  ORDER BY random()
+  LIMIT :game_count
+)
+INSERT INTO games (timestamp, id_a, name_a, char_a, platform_a, id_b, name_b, char_b, platform_b, winner, game_floor, value_a, value_b)
+SELECT
+  now() - (random() * interval '30 days'),
+  id_a, name_a, char_a, 1,
+  id_b, name_b, char_b, 1,
+  winner,
+  0,
+  GREATEST(0, value_a + (CASE WHEN winner = 1 THEN (random() * 20)::int ELSE -(random() * 20)::int END)),
+  GREATEST(0, value_b + (CASE WHEN winner = 2 THEN (random() * 20)::int ELSE -(random() * 20)::int END))
+FROM pairs;
+
+-- Vanquisher-tier matches (value >= threshold), so matchup_vanq_* has data too.
+-- Reuses the same players/chars but overrides value_a/value_b to clear the
+-- Vanquisher floor. Winner gets a higher offset band than the loser, same
+-- reasoning as the regular matches above (non-zero per-match rating change).
+WITH pool AS (
+  SELECT pr.id, pr.char_id, p.name
+  FROM player_ratings pr JOIN players p ON p.id = pr.id
+  WHERE pr.id >= :id_base
+),
+pairs AS (
+  SELECT
+    a.id AS id_a, a.name AS name_a, a.char_id AS char_a,
+    b.id AS id_b, b.name AS name_b, b.char_id AS char_b,
+    (CASE WHEN random() < 0.5 THEN 1 ELSE 2 END) AS winner
+  FROM pool a JOIN pool b ON a.id <> b.id
+  ORDER BY random()
+  LIMIT :vanq_game_count
+)
+INSERT INTO games (timestamp, id_a, name_a, char_a, platform_a, id_b, name_b, char_b, platform_b, winner, game_floor, value_a, value_b)
+SELECT
+  now() - (random() * interval '30 days'),
+  id_a, name_a, char_a, 1,
+  id_b, name_b, char_b, 1,
+  winner,
+  0,
+  :vanq_floor + (CASE WHEN winner = 1 THEN (random() * 100 + 50)::int ELSE (random() * 100)::int END),
+  :vanq_floor + (CASE WHEN winner = 2 THEN (random() * 100 + 50)::int ELSE (random() * 100)::int END)
+FROM pairs;
+
+COMMIT;
+SQL
+
+echo "Seeded $GAME_COUNT ranked games + $VANQ_GAME_COUNT Vanquisher-tier games."

--- a/scripts/seed/seed-matchups.sh
+++ b/scripts/seed/seed-matchups.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Requires seed-games.sh to have been run first. Mirrors the aggregation SQL
+# in src/pull.rs update_matchups() so the Redis payload shape matches production.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PSQL="docker exec -i pf-postgres psql -v ON_ERROR_STOP=1 -U user -d puddle_farm"
+
+ID_BASE=900000000000000
+NUM_CHARS=34
+
+matchup_json() {
+  local char_id="$1"
+  local extra_filter="$2"
+  $PSQL -tAc "
+    SELECT COALESCE(json_agg(json_build_object(
+      'opponent_char', opponent_char, 'wins', wins, 'total_games', total_games
+    )), '[]')
+    FROM (
+      SELECT
+        opponent_char,
+        SUM(CASE WHEN (position = 'a' AND winner = 1) OR (position = 'b' AND winner = 2)
+            THEN 1 ELSE 0 END) AS wins,
+        COUNT(*) AS total_games
+      FROM (
+        SELECT char_b AS opponent_char, winner, 'a' AS position
+        FROM games
+        WHERE char_a = $char_id AND id_a >= $ID_BASE  -- deviation from pull.rs: scope to seeded rows only
+          AND timestamp > now() - interval '1 month'
+          AND game_floor = 0 $extra_filter
+        UNION ALL
+        SELECT char_a AS opponent_char, winner, 'b' AS position
+        FROM games
+        WHERE char_b = $char_id AND id_b >= $ID_BASE  -- deviation from pull.rs: scope to seeded rows only
+          AND timestamp > now() - interval '1 month'
+          AND game_floor = 0 $extra_filter
+      ) combined
+      GROUP BY opponent_char
+      ORDER BY opponent_char
+    ) e;
+  "
+}
+
+GAME_COUNT=$($PSQL -tAc "SELECT count(*) FROM games WHERE id_a >= $ID_BASE;" | tr -d '\r')
+if [ "$GAME_COUNT" -eq 0 ]; then
+  echo "No seeded games found (id_a >= $ID_BASE). Run seed-games.sh first." >&2
+  exit 1
+fi
+
+for c in $(seq 0 $((NUM_CHARS - 1))); do
+  matchup_json "$c" "AND value_a > 0 AND value_b > 0" \
+    | docker exec -i pf-redis redis-cli -x SET "matchup_$c" > /dev/null
+  matchup_json "$c" "AND value_a >= 10001600 AND value_b >= 10001600" \
+    | docker exec -i pf-redis redis-cli -x SET "matchup_vanq_$c" > /dev/null
+done
+
+docker exec pf-redis redis-cli SET last_update_daily "$(date -u +"%Y-%m-%d %H:%M:%S")" > /dev/null
+
+echo "Seeded matchup_0..$((NUM_CHARS - 1)) and matchup_vanq_0..$((NUM_CHARS - 1))."

--- a/scripts/seed/seed-players.sh
+++ b/scripts/seed/seed-players.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PSQL="docker exec -i pf-postgres psql -v ON_ERROR_STOP=1 -U user -d puddle_farm"
+
+N="${1:-200}"
+ID_BASE=900000000000000
+NUM_CHARS=34
+
+# rank_idx -> [lo, hi] rating range, mirrors frontend/src/utils/Utils.jsx rankThresholds
+$PSQL -v id_base="$ID_BASE" -v n="$N" <<'SQL'
+BEGIN;
+
+DELETE FROM player_ratings WHERE id >= :id_base;
+DELETE FROM games WHERE id_a >= :id_base OR id_b >= :id_base;
+DELETE FROM player_names WHERE id >= :id_base;
+DELETE FROM players WHERE id >= :id_base;
+
+INSERT INTO players (id, name, platform)
+SELECT :id_base + s, 'TestPlayer' || s, 1
+FROM generate_series(1, :n) s;
+
+WITH ranks(idx, lo, hi) AS (
+  VALUES
+    (0, 0, 0),
+    (1, 1, 999),
+    (2, 1000, 1999),
+    (3, 2000, 2999),
+    (4, 3000, 4199),
+    (5, 4200, 5399),
+    (6, 5400, 6599),
+    (7, 6600, 8799),
+    (8, 8800, 10999),
+    (9, 11000, 13199),
+    (10, 13200, 15599),
+    (11, 15600, 17999),
+    (12, 18000, 20399),
+    (13, 20400, 24399),
+    (14, 24400, 28399),
+    (15, 28400, 32399),
+    (16, 32400, 36599),
+    (17, 36600, 40799),
+    (18, 40800, 45000)
+),
+players_gen AS (
+  SELECT s, (s % 19) AS rank_idx FROM generate_series(1, :n) s
+)
+INSERT INTO player_ratings (id, char_id, value)
+SELECT :id_base + pg.s, (pg.s % 34), r.lo + (random() * (r.hi - r.lo))::int  -- 34 == NUM_CHARS below (this heredoc can't see bash vars)
+FROM players_gen pg
+JOIN ranks r ON r.idx = pg.rank_idx;
+
+-- Give a handful of players a second character rating, so player pages have
+-- something to exercise the character switcher with (real players commonly
+-- have ratings on more than one character; every seeded player above has
+-- exactly one).
+WITH ranks(idx, lo, hi) AS (
+  VALUES
+    (0, 0, 0),
+    (1, 1, 999),
+    (2, 1000, 1999),
+    (3, 2000, 2999),
+    (4, 3000, 4199),
+    (5, 4200, 5399),
+    (6, 5400, 6599),
+    (7, 6600, 8799),
+    (8, 8800, 10999),
+    (9, 11000, 13199),
+    (10, 13200, 15599),
+    (11, 15600, 17999),
+    (12, 18000, 20399),
+    (13, 20400, 24399),
+    (14, 24400, 28399),
+    (15, 28400, 32399),
+    (16, 32400, 36599),
+    (17, 36600, 40799),
+    (18, 40800, 45000)
+),
+multi_char_players AS (
+  -- fixed set (TestPlayer1..TestPlayer8), not random, so this is reproducible run to run
+  SELECT id FROM players WHERE id > :id_base AND id <= :id_base + 8
+),
+extra_char AS (
+  SELECT
+    mcp.id,
+    (
+      SELECT c FROM generate_series(0, 33) c
+      WHERE c NOT IN (SELECT char_id FROM player_ratings WHERE player_ratings.id = mcp.id)
+      ORDER BY random() LIMIT 1
+    ) AS char_id,
+    (random() * 18)::int AS rank_idx
+  FROM multi_char_players mcp
+)
+INSERT INTO player_ratings (id, char_id, value)
+SELECT ec.id, ec.char_id, r.lo + (random() * (r.hi - r.lo))::int
+FROM extra_char ec
+JOIN ranks r ON r.idx = ec.rank_idx;
+
+COMMIT;
+SQL
+
+leaderboard_json() {
+  local char_filter="$1"
+  $PSQL -tAc "
+    SELECT COALESCE(json_agg(e), '[]') FROM (
+      SELECT
+        row_number() over (order by pr.value desc) AS rank,
+        pr.id::text AS player_id,
+        p.name AS player_name,
+        pr.char_id,
+        pr.value AS rating
+      FROM player_ratings pr
+      JOIN players p ON p.id = pr.id
+      WHERE pr.id >= $ID_BASE $char_filter
+      ORDER BY pr.value DESC
+    ) e;
+  "
+}
+
+leaderboard_json "" | docker exec -i pf-redis redis-cli -x SET leaderboard_all > /dev/null
+
+for c in $(seq 0 $((NUM_CHARS - 1))); do
+  # Always write, even "[]" - a skipped SET would leave a stale key from a
+  # previous (larger) run pointing at players that no longer exist.
+  leaderboard_json "AND pr.char_id = $c" | docker exec -i pf-redis redis-cli -x SET "leaderboard_char_$c" > /dev/null
+done
+
+LEGEND_COUNT=20
+LEGEND_DR_OFFSET=10000000
+$PSQL -tAc "
+  SELECT COALESCE(json_agg(e), '[]') FROM (
+    SELECT
+      row_number() over (order by pr.value desc) AS rank,
+      pr.id::text AS player_id,
+      p.name AS player_name,
+      pr.char_id,
+      pr.value + $LEGEND_DR_OFFSET AS rating
+    FROM player_ratings pr
+    JOIN players p ON p.id = pr.id
+    WHERE pr.id >= $ID_BASE
+    ORDER BY pr.value DESC
+    LIMIT $LEGEND_COUNT
+  ) e;
+" | docker exec -i pf-redis redis-cli -x SET leaderboard_legend > /dev/null
+
+echo "Seeded $N players (id $((ID_BASE + 1))-$((ID_BASE + N))) across 19 rank tiers, top $LEGEND_COUNT marked as legend, 8 with a second character."

--- a/scripts/seed/seed-popularity.sh
+++ b/scripts/seed/seed-popularity.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Requires seed-games.sh to have been run first (all queries read from games).
+# Mirrors src/pull.rs update_popularity(); the `id_a`/`id_b >= $ID_BASE` filters
+# below are the one deviation, scoping every query to seeded rows only.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PSQL="docker exec -i pf-postgres psql -v ON_ERROR_STOP=1 -U user -d puddle_farm"
+
+ID_BASE=900000000000000
+# Must stay in the same order as CHAR_NAMES in src/main.rs - index c below maps
+# straight to CHAR_SHORT[c], so a reorder on either side silently mislabels data.
+CHAR_SHORT=(SO KY MA AX CH PO FA MI ZA RA LE NA GI AN IN GO JC HA BA TE BI SI BE AS JN EL AB SL DI VE UN LU JA RK)
+
+per_player_counts() {
+  $PSQL -tA -F'|' -c "
+    WITH chars AS (SELECT generate_series(0, 33) AS c),
+    per_player AS (
+      SELECT c, COUNT(id) AS cnt FROM (
+        SELECT g.char_a AS c, g.id_a AS id FROM games g
+          WHERE g.timestamp > now() - interval '1 month' AND g.id_a >= $ID_BASE
+        UNION
+        SELECT g.char_b AS c, g.id_b AS id FROM games g
+          WHERE g.timestamp > now() - interval '1 month' AND g.id_b >= $ID_BASE
+      ) combined GROUP BY c
+    )
+    SELECT chars.c, COALESCE(per_player.cnt, 0)
+    FROM chars LEFT JOIN per_player ON chars.c = per_player.c
+    ORDER BY chars.c;
+  "
+}
+
+per_character_counts() {
+  $PSQL -tA -F'|' -c "
+    WITH chars AS (SELECT generate_series(0, 33) AS c),
+    per_char AS (
+      SELECT c, COUNT(c) AS cnt FROM (
+        SELECT g.char_a AS c FROM games g
+          WHERE g.timestamp > now() - interval '1 month' AND g.id_a >= $ID_BASE
+        UNION ALL
+        SELECT g.char_b AS c FROM games g
+          WHERE g.timestamp > now() - interval '1 month' AND g.id_b >= $ID_BASE
+      ) combined GROUP BY c
+    )
+    SELECT chars.c, COALESCE(per_char.cnt, 0)
+    FROM chars LEFT JOIN per_char ON chars.c = per_char.c
+    ORDER BY chars.c;
+  "
+}
+
+GAME_COUNT=$($PSQL -tAc "SELECT count(*) FROM games WHERE id_a >= $ID_BASE;" | tr -d '\r')
+if [ "$GAME_COUNT" -eq 0 ]; then
+  echo "No seeded games found (id_a >= $ID_BASE). Run seed-games.sh first." >&2
+  exit 1
+fi
+
+# Captured into a variable (not read from a process substitution directly) so
+# that `set -e` actually sees a failure in per_player_counts/per_character_counts.
+per_player_data=$(per_player_counts | tr -d '\r')
+while IFS='|' read -r c count; do
+  docker exec pf-redis redis-cli SET "popularity_per_player_${CHAR_SHORT[$c]}" "$count" > /dev/null
+done <<< "$per_player_data"
+
+per_character_data=$(per_character_counts | tr -d '\r')
+while IFS='|' read -r c count; do
+  docker exec pf-redis redis-cli SET "popularity_per_character_${CHAR_SHORT[$c]}" "$count" > /dev/null
+done <<< "$per_character_data"
+
+TOTAL_PLAYERS=$($PSQL -tAc "
+  SELECT COUNT(id) FROM (
+    SELECT g.id_a AS id FROM games g WHERE g.timestamp > now() - interval '1 month' AND g.id_a >= $ID_BASE
+    UNION
+    SELECT g.id_b AS id FROM games g WHERE g.timestamp > now() - interval '1 month' AND g.id_b >= $ID_BASE
+  ) combined;
+" | tr -d '\r')
+docker exec pf-redis redis-cli SET popularity_per_player_total "$TOTAL_PLAYERS" > /dev/null
+
+ONE_MONTH_GAMES=$($PSQL -tAc "
+  SELECT COUNT(*) FROM games WHERE timestamp > now() - interval '1 month' AND id_a >= $ID_BASE;
+" | tr -d '\r')
+docker exec pf-redis redis-cli SET one_month_games "$ONE_MONTH_GAMES" > /dev/null
+docker exec pf-redis redis-cli SET last_update_daily "$(date -u +"%Y-%m-%d %H:%M:%S")" > /dev/null
+
+echo "Seeded popularity_per_player_*, popularity_per_character_* (total_players=$TOTAL_PLAYERS, one_month_games=$ONE_MONTH_GAMES)."


### PR DESCRIPTION
Closes #33

## Why

Local backend setup currently needs a native Postgres + Redis + `diesel_cli`
install.
Even once it's running, the DB is empty until `cargo run pull` has
synced real match data from a logged-in Steam client - so there's no fast way
to check what a page actually looks like while working on the frontend.

## What this adds

- `docker/docker-compose.dev.yml` + `docker/diesel/Dockerfile` - optional
  Postgres 18 + Redis containers, plus a disposable `diesel_cli` image (built
  from `rust:slim`, no native libpq needed) for running migrations.
- `scripts/seed/*.sh` - generates dummy players/ratings/games and aggregates
  them into the same Redis keys the real `src/pull.rs` jobs
  (`update_matchups`/`update_distribution`/`update_popularity`) produce, so
  Top, Legend, per-character rankings, search, Popularity, Matchup Tables, and
  Rank Distribution all have something to render. See
  `scripts/seed/README.md` for exactly what gets created and the dependency
  order between scripts.
- A short "Development database (Docker, optional)" section in the main
  README pointing at both.

## What this doesn't change

Nothing about the existing native setup path (Requirements, manual
Postgres/Redis/diesel_cli install, `cargo run`/`cargo run pull`) is touched -
this is purely additive and opt-in.

## Testing

Verified end-to-end: `scripts/seed/reset.sh` (recreate containers +
migrate) -> `scripts/seed/seed-all.sh` (seed) -> every affected API endpoint
returns seeded data -> spot-checked in the frontend (rankings, legend tier,
search, matchup tables, popularity, rank distribution, per-match rating change
display, multi-character player pages).