### PR TITLE
feat: add Losses column to matchup table

### DIFF
--- a/frontend/src/components/PlayerMatchup.tsx
+++ b/frontend/src/components/PlayerMatchup.tsx
@@ -458,7 +458,7 @@ const Matchup = ({ API_ENDPOINT, char_short, player_id }: MatchupProps) => {
             </Typography>
           </Box>
           {viewMode === "table" ? (
-            <TableContainer component={Paper} sx={{ maxWidth: 500 }}>
+            <TableContainer component={Paper} sx={{ maxWidth: 600 }}>
               <Table stickyHeader>
                 <TableHead>
                   <TableRow>

--- a/frontend/src/components/PlayerMatchup.tsx
+++ b/frontend/src/components/PlayerMatchup.tsx
@@ -162,6 +162,8 @@ const Matchup = ({ API_ENDPOINT, char_short, player_id }: MatchupProps) => {
             return (a.wins / a.total_games) * 100;
           case "wins":
             return a.wins;
+          case "losses":
+            return a.total_games - a.wins;
           case "total":
             return a.total_games;
           default:
@@ -177,6 +179,8 @@ const Matchup = ({ API_ENDPOINT, char_short, player_id }: MatchupProps) => {
             return (b.wins / b.total_games) * 100;
           case "wins":
             return b.wins;
+          case "losses":
+            return b.total_games - b.wins;
           case "total":
             return b.total_games;
           default:
@@ -487,6 +491,15 @@ const Matchup = ({ API_ENDPOINT, char_short, player_id }: MatchupProps) => {
                     </TableCell>
                     <TableCell sx={{ position: "sticky", top: 0, zIndex: 1 }}>
                       <TableSortLabel
+                        active={orderBy === "losses"}
+                        direction={orderBy === "losses" ? order : "asc"}
+                        onClick={() => handleRequestSort("losses")}
+                      >
+                        Losses
+                      </TableSortLabel>
+                    </TableCell>
+                    <TableCell sx={{ position: "sticky", top: 0, zIndex: 1 }}>
+                      <TableSortLabel
                         active={orderBy === "total"}
                         direction={orderBy === "total" ? order : "asc"}
                         onClick={() => handleRequestSort("total")}
@@ -532,6 +545,9 @@ const Matchup = ({ API_ENDPOINT, char_short, player_id }: MatchupProps) => {
                           )}
                         </TableCell>
                         <TableCell>{matchup.wins}</TableCell>
+                        <TableCell>
+                          {matchup.total_games - matchup.wins}
+                        </TableCell>
                         <TableCell>{matchup.total_games}</TableCell>
                         <TableCell>
                           {globalWRStr !== null


### PR DESCRIPTION
## Why

The per-character matchup table on a player's page shows Wins and Total games but not Losses, requiring manual subtraction for every row (#38).

## What

- Add a Losses column to the matchup table, next to Wins
- Add sorting support for the Losses column

## Testing

- `npm run typecheck` / `npm run check` / `npm run test` all pass
- Verified in the running app against production data: values are consistent (wins + losses = total), and sorting works correctly

Closes #38