### PR TITLE
feat: consolidate Popularity tables into single sortable table

### DIFF
--- a/frontend/src/hooks/usePopularity.test.ts
+++ b/frontend/src/hooks/usePopularity.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { fetchPopularity, usePopularityPromise } from "./usePopularity";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const SAMPLE_RESPONSE = {
+  per_player: [{ name: "Sol", value: 10 }],
+  per_player_total: 100,
+  per_character: [{ name: "Sol", value: 5 }],
+  per_character_total: 50,
+  last_update: "2026-01-01 00:00:00",
+};
+
+describe("fetchPopularity", () => {
+  test("returns parsed JSON on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve(SAMPLE_RESPONSE),
+      }),
+    );
+
+    const result = await fetchPopularity();
+
+    expect(result).toEqual(SAMPLE_RESPONSE);
+  });
+
+  test("returns undefined when fetch rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network error")),
+    );
+
+    const result = await fetchPopularity();
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("usePopularityPromise", () => {
+  test("returns the same promise across re-renders", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve(SAMPLE_RESPONSE),
+      }),
+    );
+
+    const { result, rerender } = renderHook(() => usePopularityPromise());
+    const firstPromise = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(firstPromise);
+  });
+
+  test("only calls fetch once across re-renders", () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(SAMPLE_RESPONSE),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = renderHook(() => usePopularityPromise());
+    rerender();
+    rerender();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/usePopularity.ts
+++ b/frontend/src/hooks/usePopularity.ts
@@ -1,0 +1,18 @@
+import { useRef } from "react";
+import type { PopularityResult } from "../interfaces/API";
+
+const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+
+export function fetchPopularity(): Promise<PopularityResult | undefined> {
+  return fetch(`${API_ENDPOINT}/popularity`)
+    .then((res) => res.json())
+    .catch(() => undefined);
+}
+
+export function usePopularityPromise(): Promise<PopularityResult | undefined> {
+  const cacheRef = useRef<Promise<PopularityResult | undefined> | null>(null);
+  if (!cacheRef.current) {
+    cacheRef.current = fetchPopularity();
+  }
+  return cacheRef.current;
+}

--- a/frontend/src/pages/Popularity.test.ts
+++ b/frontend/src/pages/Popularity.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { nextSortState, sortPopularityData } from "./Popularity";
+
+describe("nextSortState", () => {
+  test("unsorted -> character click -> reversed", () => {
+    expect(nextSortState(null, "character")).toEqual({
+      column: "character",
+      direction: "reversed",
+    });
+  });
+
+  test("character reversed -> character click -> unsorted", () => {
+    expect(
+      nextSortState(
+        { column: "character", direction: "reversed" },
+        "character",
+      ),
+    ).toBeNull();
+  });
+
+  test("unsorted -> popularity click -> descending", () => {
+    expect(nextSortState(null, "popularity")).toEqual({
+      column: "popularity",
+      direction: "desc",
+    });
+  });
+
+  test("popularity descending -> popularity click -> ascending", () => {
+    expect(
+      nextSortState({ column: "popularity", direction: "desc" }, "popularity"),
+    ).toEqual({ column: "popularity", direction: "asc" });
+  });
+
+  test("popularity ascending -> popularity click -> unsorted", () => {
+    expect(
+      nextSortState({ column: "popularity", direction: "asc" }, "popularity"),
+    ).toBeNull();
+  });
+
+  test("sorted by character -> popularity click -> switches to popularity (exclusive)", () => {
+    expect(
+      nextSortState(
+        { column: "character", direction: "reversed" },
+        "popularity",
+      ),
+    ).toEqual({ column: "popularity", direction: "desc" });
+  });
+
+  test("sorted by popularity -> character click -> switches to character (exclusive)", () => {
+    expect(
+      nextSortState({ column: "popularity", direction: "asc" }, "character"),
+    ).toEqual({ column: "character", direction: "reversed" });
+  });
+});
+
+describe("sortPopularityData", () => {
+  const items = [
+    { name: "Sol", value: 30 },
+    { name: "Ky", value: 10 },
+    { name: "Ramlethal", value: 20 },
+  ];
+
+  test("returns items in original order when sortState is null", () => {
+    expect(sortPopularityData(items, null)).toEqual(items);
+  });
+
+  test("sorts descending by popularity value", () => {
+    expect(
+      sortPopularityData(items, { column: "popularity", direction: "desc" }),
+    ).toEqual([
+      { name: "Sol", value: 30 },
+      { name: "Ramlethal", value: 20 },
+      { name: "Ky", value: 10 },
+    ]);
+  });
+
+  test("sorts ascending by popularity value", () => {
+    expect(
+      sortPopularityData(items, { column: "popularity", direction: "asc" }),
+    ).toEqual([
+      { name: "Ky", value: 10 },
+      { name: "Ramlethal", value: 20 },
+      { name: "Sol", value: 30 },
+    ]);
+  });
+
+  test("reverses the original (API) order for character column", () => {
+    expect(
+      sortPopularityData(items, { column: "character", direction: "reversed" }),
+    ).toEqual([
+      { name: "Ramlethal", value: 20 },
+      { name: "Ky", value: 10 },
+      { name: "Sol", value: 30 },
+    ]);
+  });
+
+  test("does not mutate the original array", () => {
+    const original = [...items];
+    sortPopularityData(items, { column: "popularity", direction: "desc" });
+    sortPopularityData(items, { column: "character", direction: "reversed" });
+    expect(items).toEqual(original);
+  });
+});

--- a/frontend/src/pages/Popularity.tsx
+++ b/frontend/src/pages/Popularity.tsx
@@ -9,6 +9,7 @@ import {
   TableHead,
   TableRow,
   TableSortLabel,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { Suspense, use, useMemo, useState } from "react";
@@ -56,9 +57,11 @@ export function sortPopularityData<T extends { name: string; value: number }>(
 const PopularityTable = ({
   data,
   percentage,
+  countLabel,
 }: {
   data: PopularityResultChar[];
   percentage: (value: number) => number;
+  countLabel: string;
 }) => {
   const [sortState, setSortState] = useState<SortState>(null);
 
@@ -115,7 +118,11 @@ const PopularityTable = ({
               >
                 {e.name}
               </TableCell>
-              <TableCell>{percentage(e.value).toFixed(2)}%</TableCell>
+              <TableCell>
+                <Tooltip title={`${e.value} ${countLabel}`} arrow>
+                  <span>{percentage(e.value).toFixed(2)}%</span>
+                </Tooltip>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -156,6 +163,7 @@ const PopularityContent = ({
           percentage={(value) =>
             popularity ? (value / popularity.per_player_total) * 100 : 0
           }
+          countLabel="Players"
         />
         <Box>
           Total games per player:{" "}
@@ -182,6 +190,7 @@ const PopularityContent = ({
               ? ((value / popularity.per_character_total) * 100) / 2
               : 0
           }
+          countLabel="Games"
         />
         <Box>
           Total games per character:{" "}

--- a/frontend/src/pages/Popularity.tsx
+++ b/frontend/src/pages/Popularity.tsx
@@ -8,13 +8,121 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
   Typography,
 } from "@mui/material";
-import { Suspense, use, useState } from "react";
-import type { PopularityResult } from "../interfaces/API";
+import { Suspense, use, useMemo, useState } from "react";
+import { usePopularityPromise } from "../hooks/usePopularity";
+import type { PopularityResult, PopularityResultChar } from "../interfaces/API";
 import { Utils } from "./../utils/Utils";
 
-const API_ENDPOINT = import.meta.env.VITE_API_ENDPOINT;
+export type SortColumn = "character" | "popularity";
+export type SortState =
+  | { column: "character"; direction: "reversed" }
+  | { column: "popularity"; direction: "asc" | "desc" }
+  | null;
+
+export function nextSortState(
+  current: SortState,
+  clicked: SortColumn,
+): SortState {
+  if (clicked === "character") {
+    return current?.column === "character"
+      ? null
+      : { column: "character", direction: "reversed" };
+  }
+  if (current === null || current.column !== "popularity") {
+    return { column: "popularity", direction: "desc" };
+  }
+  return current.direction === "desc"
+    ? { column: "popularity", direction: "asc" }
+    : null;
+}
+
+export function sortPopularityData<T extends { name: string; value: number }>(
+  items: T[],
+  sortState: SortState,
+): T[] {
+  if (sortState === null) {
+    return items;
+  }
+  if (sortState.column === "character") {
+    return [...items].reverse();
+  }
+  const sorted = [...items].sort((a, b) => a.value - b.value);
+  return sortState.direction === "asc" ? sorted : sorted.reverse();
+}
+
+const PopularityTable = ({
+  data,
+  percentage,
+}: {
+  data: PopularityResultChar[];
+  percentage: (value: number) => number;
+}) => {
+  const [sortState, setSortState] = useState<SortState>(null);
+
+  const sorted = useMemo(
+    () => sortPopularityData(data, sortState),
+    [data, sortState],
+  );
+
+  return (
+    <TableContainer component={Paper} sx={{ maxWidth: 400, marginBottom: 4 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>
+              <TableSortLabel
+                active={sortState?.column === "character"}
+                direction={sortState?.column === "character" ? "desc" : "asc"}
+                onClick={() =>
+                  setSortState(nextSortState(sortState, "character"))
+                }
+              >
+                Character
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortState?.column === "popularity"}
+                direction={
+                  sortState?.column === "popularity"
+                    ? sortState.direction
+                    : "desc"
+                }
+                onClick={() =>
+                  setSortState(nextSortState(sortState, "popularity"))
+                }
+              >
+                Popularity
+              </TableSortLabel>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted.map((e) => (
+            <TableRow key={e.name}>
+              <TableCell
+                component="th"
+                scope="row"
+                sx={{
+                  position: "sticky",
+                  left: 0,
+                  background: "black",
+                  zIndex: 1,
+                }}
+              >
+                {e.name}
+              </TableCell>
+              <TableCell>{percentage(e.value).toFixed(2)}%</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
 
 const PopularityContent = ({
   data,
@@ -43,49 +151,12 @@ const PopularityContent = ({
             It adds up to over 100% because players can use multiple characters.
           </Typography>
         </Box>
-        <Box sx={{ display: "flex", flexWrap: "wrap" }}>
-          {popularity?.per_player
-            .reduce<Array<typeof popularity.per_player>>((acc, e, index) => {
-              const groupIndex = Math.floor(index / 10);
-              if (!acc[groupIndex]) {
-                acc[groupIndex] = [];
-              }
-              acc[groupIndex].push(e);
-              return acc;
-            }, [])
-            .map((group, groupIndex) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: synthetic group index, no stable id
-              <Box key={groupIndex} sx={{ width: "300px" }}>
-                <TableContainer
-                  component={Paper}
-                  sx={{ marginBottom: 4, marginRight: 2 }}
-                >
-                  <Table>
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Character</TableCell>
-                        <TableCell>Popularity</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {group.map((e) => (
-                        <TableRow key={e.name}>
-                          <TableCell>{e.name}</TableCell>
-                          <TableCell>
-                            {(
-                              (e.value / popularity.per_player_total) *
-                              100
-                            ).toFixed(2)}
-                            %
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              </Box>
-            ))}
-        </Box>
+        <PopularityTable
+          data={popularity?.per_player ?? []}
+          percentage={(value) =>
+            popularity ? (value / popularity.per_player_total) * 100 : 0
+          }
+        />
         <Box>
           Total games per player:{" "}
           {popularity && Utils.formatNumber(popularity.per_player_total)}
@@ -104,50 +175,14 @@ const PopularityContent = ({
             <br />
           </Typography>
         </Box>
-        <Box sx={{ display: "flex", flexWrap: "wrap" }}>
-          {popularity?.per_character
-            .reduce<Array<typeof popularity.per_character>>((acc, e, index) => {
-              const groupIndex = Math.floor(index / 10);
-              if (!acc[groupIndex]) {
-                acc[groupIndex] = [];
-              }
-              acc[groupIndex].push(e);
-              return acc;
-            }, [])
-            .map((group, groupIndex) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: synthetic group index, no stable id
-              <Box key={groupIndex} sx={{ width: "300px" }}>
-                <TableContainer
-                  component={Paper}
-                  sx={{ marginBottom: 4, marginRight: 2 }}
-                >
-                  <Table>
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Character</TableCell>
-                        <TableCell>Popularity</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {group.map((e) => (
-                        <TableRow key={e.name}>
-                          <TableCell>{e.name}</TableCell>
-                          <TableCell>
-                            {(
-                              ((e.value / popularity.per_character_total) *
-                                100) /
-                              2
-                            ).toFixed(2)}
-                            %
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              </Box>
-            ))}
-        </Box>
+        <PopularityTable
+          data={popularity?.per_character ?? []}
+          percentage={(value) =>
+            popularity
+              ? ((value / popularity.per_character_total) * 100) / 2
+              : 0
+          }
+        />
         <Box>
           Total games per character:{" "}
           {popularity && Utils.formatNumber(popularity.per_character_total * 2)}
@@ -166,12 +201,7 @@ const PopularityContent = ({
 };
 
 const Popularity = () => {
-  const [popularityPromise] = useState(
-    (): Promise<PopularityResult | undefined> =>
-      fetch(`${API_ENDPOINT}/popularity`)
-        .then((res) => res.json())
-        .catch(() => undefined),
-  );
+  const popularityPromise = usePopularityPromise();
 
   return (
     <>


### PR DESCRIPTION
## Why

The Per Player / Per Character tables on the Popularity page grouped characters into chunks of 10 laid out as multiple side-by-side small tables, forcing a zigzag reading pattern, no sorting, and layout breakage on mobile width (#40).

## What
- Replace the grouped small-table layout with a single scrollable table per section
- Add sorting on the Character column (toggles between API order and its reverse) and the Popularity column (unsorted → descending → ascending), mutually exclusive between the two
- Character column styling matches the Matchup table (sticky, `th`, black background)
- Extract data fetching into a `usePopularityPromise` hook, following the same pattern established for TopGlobal/TopPlayer

## Testing
- `npm run typecheck` / `npm run check` / `npm run test` all pass (153 tests)
- Verified in the running app against production data: sorting works correctly on both columns, exclusivity holds, layout matches Matchup table styling, no regressions on mobile width

Closes #40