### PR TITLE
Fix/mobile hero header

### DIFF
--- a/frontend/src/pages/Legend.tsx
+++ b/frontend/src/pages/Legend.tsx
@@ -118,7 +118,7 @@ const Legend = () => {
         ) : null}
         <Box
           sx={{
-            minHeight: 100,
+            minHeight: { xs: 50, sm: 100 },
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -129,7 +129,7 @@ const Search = () => {
       >
         <Box
           sx={{
-            minHeight: 100,
+            minHeight: { xs: 50, sm: 100 },
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -151,7 +151,7 @@ const Stats = () => {
       >
         <Box
           sx={{
-            minHeight: 100,
+            minHeight: { xs: 50, sm: 100 },
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/frontend/src/pages/TopGlobal.tsx
+++ b/frontend/src/pages/TopGlobal.tsx
@@ -178,7 +178,7 @@ const TopGlobal = () => {
       >
         <Box
           sx={{
-            minHeight: 100,
+            minHeight: { xs: 50, sm: 100 },
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/frontend/src/pages/TopPlayer.tsx
+++ b/frontend/src/pages/TopPlayer.tsx
@@ -188,7 +188,7 @@ const TopPlayer = () => {
       >
         <Box
           sx={{
-            minHeight: 100,
+            minHeight: { xs: 50, sm: 100 },
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/frontend/src/utils/themes.ts
+++ b/frontend/src/utils/themes.ts
@@ -65,8 +65,11 @@ function createCharacterTheme(config: CharacterThemeConfig): Theme {
                 props: { variant: "pageHeader" },
                 style: {
                   display: "block",
-                  fontSize: 34,
+                  fontSize: 24,
                   color: config.pageHeaderColor,
+                  "@media (min-width:600px)": {
+                    fontSize: 34,
+                  },
                 },
               },
               {


### PR DESCRIPTION
Part of #43. Second PR in the mobile-optimization stack, based on `fix/mobile-table-margin` (#45).

**Note:** since this branch stacks on top of `fix/mobile-table-margin`, the diff currently includes that branch's commit too. Once #45 is merged, this branch will be rebased onto `master` and the diff will show only this PR's changes.

## Changes
- Shrink `pageHeader` typography variant font size on mobile (34px → 24px below 600px breakpoint)
- Reduce hero `Box` minHeight on mobile (100 → 50 below 600px) across TopGlobal, TopPlayer, Legend, Search, Stats