### PR TITLE
fix: rework mobile match history layout in new HistoryCard component

### DIFF
--- a/frontend/src/components/HistoryCard.tsx
+++ b/frontend/src/components/HistoryCard.tsx
@@ -1,0 +1,193 @@
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import {
+  Box,
+  Button,
+  Collapse,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import type { TagResponse } from "../interfaces/API";
+import type { GroupedMatch, MatchWithRating } from "../interfaces/Player";
+import { Utils } from "../utils/Utils";
+import { RatingChangeLabel } from "./RatingChangeLabel";
+import { Tag } from "./Tag";
+
+function MatchDetailTable({ matches }: { matches: MatchWithRating[] }) {
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell sx={{ px: 0.5 }}>Time</TableCell>
+          <TableCell align="right" sx={{ px: 0.5 }}>
+            Rating
+          </TableCell>
+          <TableCell align="right" sx={{ px: 0.5 }}>
+            Opp Rating
+          </TableCell>
+          <TableCell align="right" sx={{ px: 0.5 }}>
+            Win?
+          </TableCell>
+          <TableCell align="right" sx={{ px: 0.5 }}>
+            Change
+          </TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {matches.map((item) => (
+          <TableRow key={item.timestamp}>
+            <TableCell component="th" scope="row" sx={{ px: 0.5 }}>
+              {Utils.formatUTCToLocal(item.timestamp)}
+            </TableCell>
+            <TableCell align="right" sx={{ px: 0.5 }}>
+              {Utils.displayRating(item.own_rating_value)}
+            </TableCell>
+            <TableCell align="right" sx={{ px: 0.5 }}>
+              {Utils.displayRating(item.opponent_rating_value)}
+            </TableCell>
+            <TableCell align="right" sx={{ px: 0.5 }}>
+              {item.result_win ? "Y" : "N"}
+            </TableCell>
+            <TableCell align="right" sx={{ px: 0.5 }}>
+              {Utils.formatRatingChange(item.ratingChange)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+// labeled value: small labeled value, wraps naturally in a flex row
+function LabeledValue({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        minWidth: 0,
+        flex: "1 1 100px",
+      }}
+    >
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          lineHeight: 1.1,
+          border: 0,
+          clip: "rect(0 0 0 0)",
+          height: "1px",
+          margin: -1,
+          overflow: "hidden",
+          padding: 0,
+          position: "absolute",
+          whiteSpace: "nowrap",
+          width: "1px",
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ lineHeight: 1.2 }}>
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+function HistoryCard(props: { item?: GroupedMatch; tags?: TagResponse[] }) {
+  const [open, setOpen] = useState(false);
+
+  const { item, tags } = props;
+
+  if (!item) return null;
+
+  const lastMatch = item.matches[item.matches.length - 1];
+
+  return (
+    <Box component={Paper} sx={{ p: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <IconButton
+          aria-label="expand row"
+          size="small"
+          onClick={() => setOpen(!open)}
+        >
+          {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+        </IconButton>
+        <Button
+          component={Link}
+          sx={{ justifyContent: "flex-start", minWidth: "auto" }}
+          to={`/player/${item.opponent_id}/${item.matches[0].opponent_character_short}`}
+        >
+          {item.opponent_name}
+        </Button>
+        {tags?.map((e: TagResponse) => (
+          <Tag
+            key={e.tag}
+            style={JSON.parse(e.style)}
+            sx={{ fontSize: "0.9rem" }}
+          >
+            {e.tag}
+          </Tag>
+        ))}
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "flex-start",
+          gap: 1.5,
+          px: 1,
+          py: 0.5,
+          alignItems: "center",
+        }}
+      >
+        <LabeledValue label="Time">
+          {Utils.formatUTCToLocal(item.timestamp)}
+        </LabeledValue>
+        <LabeledValue label="Rating">
+          {Utils.displayRating(lastMatch.own_rating_value)}
+        </LabeledValue>
+        <LabeledValue label="Result">
+          {item.wins} - {item.losses}
+        </LabeledValue>
+        <LabeledValue label="Char">
+          {item.matches[0].opponent_character_short}
+        </LabeledValue>
+        <LabeledValue label="Opp Rating">
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            {Utils.displayRankIcon(
+              lastMatch.opponent_rating_value,
+              "20px",
+              lastMatch.opponent_is_legend,
+            )}
+            {Utils.displayRating(lastMatch.opponent_rating_value)}
+          </Box>
+        </LabeledValue>
+        <LabeledValue label="Change">
+          <RatingChangeLabel change={item.ratingChange} />
+        </LabeledValue>
+      </Box>
+
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <MatchDetailTable matches={item.matches} />
+      </Collapse>
+    </Box>
+  );
+}
+
+export default HistoryCard;

--- a/frontend/src/components/HistoryRow.tsx
+++ b/frontend/src/components/HistoryRow.tsx
@@ -5,11 +5,9 @@ import {
   Button,
   Collapse,
   IconButton,
-  Paper,
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
 } from "@mui/material";
@@ -20,12 +18,6 @@ import type { GroupedMatch, MatchWithRating } from "../interfaces/Player";
 import { Utils } from "../utils/Utils";
 import { RatingChangeLabel } from "./RatingChangeLabel";
 import { Tag } from "./Tag";
-
-function formatRatingChange(ratingChange: string | undefined): string {
-  const sign =
-    ratingChange !== undefined && parseFloat(ratingChange) > 0 ? "+" : "";
-  return `${sign}${ratingChange}`;
-}
 
 function MatchDetailTable({ matches }: { matches: MatchWithRating[] }) {
   return (
@@ -53,7 +45,7 @@ function MatchDetailTable({ matches }: { matches: MatchWithRating[] }) {
             </TableCell>
             <TableCell align="right">{item.result_win ? "Y" : "N"}</TableCell>
             <TableCell align="right">
-              {formatRatingChange(item.ratingChange)}
+              {Utils.formatRatingChange(item.ratingChange)}
             </TableCell>
           </TableRow>
         ))}
@@ -62,189 +54,86 @@ function MatchDetailTable({ matches }: { matches: MatchWithRating[] }) {
   );
 }
 
-function HistoryRow(props: {
-  isMobile?: boolean;
-  item?: GroupedMatch;
-  tags?: TagResponse[];
-}) {
+function HistoryRow(props: { item?: GroupedMatch; tags?: TagResponse[] }) {
   const [open, setOpen] = useState(false);
 
   const { item, tags } = props;
 
   if (!item) return null;
 
-  const formatTimestamp = (timestamp: string) => {
-    const [date, time] = Utils.formatUTCToLocal(timestamp).split(" ");
-    return (
-      <>
-        <Box sx={{ p: 0, m: 0 }}>{date}</Box>
-        <Box sx={{ p: 0, m: 0 }}>{time}</Box>
-      </>
-    );
-  };
-
-  if (props.isMobile) {
-    return (
-      <TableContainer component={Paper}>
-        <Table size="small">
-          <TableBody>
-            <TableRow>
-              <TableCell sx={{ p: 0, m: 0 }}>
-                <IconButton
-                  aria-label="expand row"
-                  size="small"
-                  onClick={() => setOpen(!open)}
-                >
-                  {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-                </IconButton>
-              </TableCell>
-              <TableCell sx={{ px: 0, mx: 0 }} width={90}>
-                {formatTimestamp(item.timestamp)}
-              </TableCell>
-              <TableCell sx={{ px: 0, mx: 0 }} width={90}>
-                {" "}
-                {Utils.displayRating(
-                  item.matches[item.matches.length - 1].own_rating_value,
-                )}
-              </TableCell>
-              <TableCell sx={{ px: 0, mx: 0 }}>
-                {item.wins} - {item.losses}
-              </TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell sx={{ px: 0, mx: 0, maxWidth: "120px" }}>
-                <Button
-                  sx={{
-                    marginLeft: "5px",
-                    justifyContent: "flex-start",
-                    minWidth: "auto",
-                  }}
-                  component={Link}
-                  to={`/player/${item.opponent_id}/${item.matches[0].opponent_character_short}`}
-                >
-                  {item.opponent_name}
-                </Button>
-                <Box>
-                  {tags?.map((e: TagResponse) => (
-                    <Tag
-                      key={e.tag}
-                      style={JSON.parse(e.style)}
-                      sx={{ fontSize: "0.9rem" }}
-                    >
-                      {e.tag}
-                    </Tag>
-                  ))}
-                </Box>
-              </TableCell>
-              <TableCell>
-                {Utils.displayRankIcon(
-                  item.matches[item.matches.length - 1].opponent_rating_value,
-                  "32px",
-                  item.matches[item.matches.length - 1].opponent_is_legend,
-                )}
-              </TableCell>
-              <TableCell sx={{ px: 0, mx: 0 }}>
-                {Utils.displayRating(
-                  item.matches[item.matches.length - 1].opponent_rating_value,
-                )}
-              </TableCell>
-              <TableCell sx={{ px: 0, mx: 0 }}>
-                {item.matches[0].opponent_character_short}
-              </TableCell>
-              <TableCell sx={{ px: 0, mx: 0 }}>
-                <RatingChangeLabel change={item.ratingChange} />
-              </TableCell>
-            </TableRow>
-
-            <TableRow id={item.timestamp}>
-              <TableCell
-                style={{ paddingBottom: 0, paddingTop: 0 }}
-                colSpan={8}
+  return (
+    <>
+      <TableRow sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+        <TableCell>
+          <IconButton
+            aria-label="expand row"
+            size="small"
+            onClick={() => setOpen(!open)}
+          >
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell component="th" scope="row">
+          {Utils.formatUTCToLocal(item.timestamp)}
+        </TableCell>
+        <TableCell align="right">
+          <Box component={"span"}>
+            {Utils.displayRating(
+              item.matches[item.matches.length - 1].own_rating_value,
+            )}
+          </Box>
+        </TableCell>
+        <TableCell>
+          <Button
+            component={Link}
+            sx={{ justifyContent: "flex-start", minWidth: "auto" }}
+            to={`/player/${item.opponent_id}/${item.matches[0].opponent_character_short}`}
+          >
+            {item.opponent_name}
+          </Button>
+          <Box>
+            {tags?.map((e: TagResponse) => (
+              <Tag
+                key={e.tag}
+                style={JSON.parse(e.style)}
+                sx={{ fontSize: "0.9rem", position: "unset" }}
               >
-                <Collapse in={open} timeout="auto" unmountOnExit>
-                  <MatchDetailTable matches={item.matches} />
-                </Collapse>
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
-    );
-  } else {
-    return (
-      <>
-        <TableRow sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
-          <TableCell>
-            <IconButton
-              aria-label="expand row"
-              size="small"
-              onClick={() => setOpen(!open)}
-            >
-              {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-            </IconButton>
-          </TableCell>
-          <TableCell component="th" scope="row">
-            {Utils.formatUTCToLocal(item.timestamp)}
-          </TableCell>
-          <TableCell align="right">
-            <Box component={"span"}>
-              {Utils.displayRating(
-                item.matches[item.matches.length - 1].own_rating_value,
-              )}
-            </Box>
-          </TableCell>
-          <TableCell>
-            <Button
-              component={Link}
-              sx={{ justifyContent: "flex-start", minWidth: "auto" }}
-              to={`/player/${item.opponent_id}/${item.matches[0].opponent_character_short}`}
-            >
-              {item.opponent_name}
-            </Button>
-            <Box>
-              {tags?.map((e: TagResponse) => (
-                <Tag
-                  key={e.tag}
-                  style={JSON.parse(e.style)}
-                  sx={{ fontSize: "0.9rem", position: "unset" }}
-                >
-                  {e.tag}
-                </Tag>
-              ))}
-            </Box>
-          </TableCell>
-          <TableCell align="right">
-            {item.matches[0].opponent_character}
-          </TableCell>
-          <TableCell align="right">
-            <Box component={"span"}>
-              {Utils.displayRankIcon(
-                item.matches[item.matches.length - 1].opponent_rating_value,
-                "32px",
-                item.matches[item.matches.length - 1].opponent_is_legend,
-              )}{" "}
-              {Utils.displayRating(
-                item.matches[item.matches.length - 1].opponent_rating_value,
-              )}
-            </Box>
-          </TableCell>
-          <TableCell align="right">
-            {item.wins} - {item.losses}
-          </TableCell>
-          <TableCell align="right">
-            <RatingChangeLabel change={item.ratingChange} />
-          </TableCell>
-        </TableRow>
-        <TableRow id={item.timestamp}>
-          <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={8}>
-            <Collapse in={open} timeout="auto" unmountOnExit>
-              <MatchDetailTable matches={item.matches} />
-            </Collapse>
-          </TableCell>
-        </TableRow>
-      </>
-    );
-  }
+                {e.tag}
+              </Tag>
+            ))}
+          </Box>
+        </TableCell>
+        <TableCell align="right">
+          {item.matches[0].opponent_character}
+        </TableCell>
+        <TableCell align="right">
+          <Box component={"span"}>
+            {Utils.displayRankIcon(
+              item.matches[item.matches.length - 1].opponent_rating_value,
+              "32px",
+              item.matches[item.matches.length - 1].opponent_is_legend,
+            )}{" "}
+            {Utils.displayRating(
+              item.matches[item.matches.length - 1].opponent_rating_value,
+            )}
+          </Box>
+        </TableCell>
+        <TableCell align="right">
+          {item.wins} - {item.losses}
+        </TableCell>
+        <TableCell align="right">
+          <RatingChangeLabel change={item.ratingChange} />
+        </TableCell>
+      </TableRow>
+      <TableRow id={item.timestamp}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={8}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <MatchDetailTable matches={item.matches} />
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
 }
 
 export default HistoryRow;

--- a/frontend/src/pages/Player.tsx
+++ b/frontend/src/pages/Player.tsx
@@ -23,6 +23,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { type MouseEvent, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import HistoryCard from "../components/HistoryCard";
 import HistoryRow from "../components/HistoryRow";
 import Matchup from "../components/PlayerMatchup";
 import RatingChart from "../components/RatingChart";
@@ -258,9 +259,8 @@ function MatchHistory({
         {tags &&
           filteredHistory.map((item) => (
             <Box sx={{ py: 0.3 }} key={`${item.timestamp}-${item.opponent_id}`}>
-              <HistoryRow
+              <HistoryCard
                 item={item}
-                isMobile={true}
                 tags={tags[item.opponent_id.toString()]}
               />
             </Box>

--- a/frontend/src/utils/Utils.tsx
+++ b/frontend/src/utils/Utils.tsx
@@ -265,6 +265,11 @@ const Utils = {
     const sec = s % 60;
     return `${h}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
   },
+  formatRatingChange: (ratingChange: string | undefined): string => {
+    const sign =
+      ratingChange !== undefined && parseFloat(ratingChange) > 0 ? "+" : "";
+    return `${sign}${ratingChange}`;
+  },
 };
 
 export { Utils };


### PR DESCRIPTION
- Add HistoryCard: mobile match history summary using Box/Flex layout, replacing the header-less `<table>` row that previously lived in HistoryRow's isMobile branch
- Remove the isMobile branch from HistoryRow (desktop table only)
- Shorten MatchDetailTable headers and stack the timestamp on two lines so the expanded detail table fits without horizontal scroll on mobile
- Move formatRatingChange into Utils, now that both HistoryRow and the new HistoryCard need it

Refs #43